### PR TITLE
Add ADMIN_PASSWORD environment variable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure the scripts use LF line endings, not CRLF
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-
 ENV PORT=8211 \
     PLAYERS=16 \
     MULTITHREADING=false \
@@ -15,6 +14,7 @@ ENV PORT=8211 \
     PUBLIC_PORT= \
     SERVER_PASSWORD= \
     SERVER_NAME= \
+    ADMIN_PASSWORLD= \
     UPDATE_ON_BOOT=true
 
 COPY ./scripts/* /home/steam/server/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV PORT=8211 \
     PUBLIC_PORT= \
     SERVER_PASSWORD= \
     SERVER_NAME= \
-    ADMIN_PASSWORLD= \
+    ADMIN_PASSWORD= \
     UPDATE_ON_BOOT=true
 
 COPY ./scripts/* /home/steam/server/

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It is highly recommended you set the following environment values before startin
 * MULTITHREADING
 
 | Variable         | Info                                                                                                                                                                                               | Default Values | Allowed Values |
-|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|----------------|
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------- |
 | PLAYERS*         | Max amount of players that are able to join the server                                                                                                                                             | 16             | 1-31           |
 | PORT*            | UDP port that the server will expose                                                                                                                                                               | 8211           | 1024-65535     |
 | MULTITHREADING** | Improves performance in multi-threaded CPU environments. It is effective up to a maximum of about 4 threads, and allocating more than this number of threads does not make much sense.             | false          | true/false     |
@@ -75,7 +75,9 @@ It is highly recommended you set the following environment values before startin
 | PUBLIC_PORT      | You can manually specify the port number of the network on which the server running.If not specified, it will be detected automatically. If it does not work well, try manual configuration.       |                | x.x.x.x        |
 | SERVER_NAME      | A name for your community server                                                                                                                                                                   |                | "string"       |
 | SERVER_PASSWORD  | Secure your community server with a password                                                                                                                                                       |                | "string"       |
+| ADMIN_PASSWORD   | Secure administration access in the server with a password                                                                                                                                         |                | "string"       |
 | UPDATE_ON_BOOT** | Update/Install the server when the docker container starts (THIS HAS TO BE ENABLED THE FIRST TIME YOU RUN THE CONTAINER)                                                                           | true           | true/false     |
+
 
 *highly recommended to set
 
@@ -84,7 +86,7 @@ It is highly recommended you set the following environment values before startin
 ### Game Ports
 
 | Port  | Info             | note                                           |
-|-------|------------------|------------------------------------------------|
+| ----- | ---------------- | ---------------------------------------------- |
 | 8211  | Game Port (UDP)  |                                                |
 | 27015 | Query Port (UDP) | You are not able to change this port as of now |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,6 @@ services:
          # Enable the environment variables below if you have COMMUNITY=true
          # - SERVER_PASSWORD="worldofpals"
          # - SERVER_NAME="World of Pals"
+         # - ADMIN_PASSWORD="someAdminPassword"
       volumes:
          - ./palworld:/palworld/

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -24,6 +24,10 @@ if [ -n "${SERVER_PASSWORD}" ]; then
     STARTCOMMAND="${STARTCOMMAND} -serverpassword=${SERVER_PASSWORD}"
 fi
 
+if [ -n "${ADMIN_PASSWORD}" ]; then
+    STARTCOMMAND="${STARTCOMMAND} -adminpassword=${ADMIN_PASSWORD}"
+fi
+
 if [ "${MULTITHREADING}" = true ]; then
     STARTCOMMAND="${STARTCOMMAND} -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS"
 fi 


### PR DESCRIPTION
# Motivations
Being able to configure the admin password would be quite helpful

# Modifications
- Add `.gitattributes`, to ensure the scripts use LF line endings
- Add `ADMIN_PASSWORD` to the list of environment variables, which adds `--adminpassword` to the server arguments, this has been verified to work locally