### PR TITLE
Include RCON in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@ LABEL maintainer="thijs@loef.dev"
 RUN apt-get update && apt-get install -y --no-install-recommends \
     xdg-user-dirs=0.17-2 \
     procps=2:3.3.17-5 \
+    wget=1.21-1+deb11u1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/itzg/rcon-cli/releases/download/1.6.4/rcon-cli_1.6.4_linux_amd64.tar.gz -O - | tar -xz
+RUN mv rcon-cli /usr/bin/rcon-cli
 
 ENV PORT= \
     PUID=1000 \

--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ services:
          # - SERVER_NAME="World of Pals"
       volumes:
          - ./palworld:/palworld/
-   rcon:
-      image: outdead/rcon:latest
-      entrypoint: ['/rcon', '-a', 'palworld:25575', '-p', 'adminPasswordHere']
-      profiles: ['rcon'] 
 ```
 
 ### Docker Run
@@ -117,11 +113,13 @@ It is highly recommended you set the following environment values before startin
 ## Using RCON
 
 RCON is enabled by default for the palworld-server-docker image.
-Using the RCON commands is quite easy:
+Opening the RCON cli is quite easy:
 
 ```bash
-docker compose run --rm rcon "Server Command"
+docker exec -it palworld-server rcon-cli
 ```
+
+This will open a CLI that use can use to write commands to the Palworld Server.
 
 ### List of server commands
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,3 @@ services:
          # - SERVER_NAME="World of Pals"
       volumes:
          - ./palworld:/palworld/
-   rcon:
-      image: outdead/rcon:latest
-      entrypoint: ['/rcon', '-a', 'palworld:25575', '-p', 'adminPasswordHere']
-      profiles: ['rcon'] 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -63,6 +63,13 @@ if [ -n "${RCON_PORT}" ]; then
     sed -i "s/RCONPort=[0-9]*/RCONPort=$RCON_PORT/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 
+# Configure RCON settings
+cat >~/.rcon-cli.yaml  <<EOL
+host: localhost
+port: ${RCON_PORT}
+password: ${ADMIN_PASSWORD}
+EOL
+
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
 echo "${STARTCOMMAND}"
 su steam -c "${STARTCOMMAND}"


### PR DESCRIPTION
fixes https://github.com/thijsvanloef/palworld-server-docker/issues/64

This PR solves the need to have an external RCON container to run RCON commands to the server. 

## Known Issues:

"Weird. This response is for another request." shows up when a command is run, but the command does get executed.
Issue already exists: https://github.com/itzg/rcon-cli/issues/28