### PR TITLE
Graceful stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,15 @@ It is highly recommended you set the following environment values before startin
 | SERVER_PASSWORD  | Secure your community server with a password                                                                                                                                                       |                | "string"       |
 | ADMIN_PASSWORD   | Secure administration access in the server with a password                                                                                                                                         |                | "string"       |
 | UPDATE_ON_BOOT** | Update/Install the server when the docker container starts (THIS HAS TO BE ENABLED THE FIRST TIME YOU RUN THE CONTAINER)                                                                           | true           | true/false     |
-| RCON_ENABLED     | Enable RCON for the Palworld server                                                                                                                                                                | true           | true/false     |
+| RCON_ENABLED***     | Enable RCON for the Palworld server                                                                                                                                                                | true           | true/false     |
 | RCON_PORT        | RCON port to connect to                                                                                                                                                                            | 25575          | 1024-65535     |
 | QUERY_PORT       | Query port used to communicate with Steam servers                                                                                                                                                  | 27015          | 1024-65535     |
 
 *highly recommended to set
 
 ** Make sure you know what you are doing when running this option enabled
+
+*** Required for docker stop to save and gracefully close the server
 
 ### Game Ports
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -18,15 +18,20 @@ if [ "${UPDATE_ON_BOOT}" = true ]; then
 fi
 
 term_handler() {
-    rcon-cli shutdown 1
-    while true
-    do
-        rcon-cli info
-        if [ $? -ne 0 ]; then
-            break
-        fi
-        sleep 1 
-    done
+    if [ ${RCON_ENABLED} = true ]; then
+        rcon-cli shutdown 1
+        while true
+        do
+            rcon-cli info
+            if [ $? -ne 0 ]; then
+                break
+            fi
+            sleep 1 
+        done
+    else # Not graceful
+        kill -SIGTERM $(pidof PalServer-Linux-Test)
+        tail --pid=$(pidof PalServer-Linux-Test) -f 2>/dev/null
+    fi
 }
 
 trap 'term_handler' SIGTERM

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -19,19 +19,12 @@ fi
 
 term_handler() {
     if [ ${RCON_ENABLED} = true ]; then
+        rcon-cli save
         rcon-cli shutdown 1
-        while true
-        do
-            rcon-cli info
-            if [ $? -ne 0 ]; then
-                break
-            fi
-            sleep 1 
-        done
     else # Not graceful
-        kill -SIGTERM $(pidof PalServer-Linux-Test)
-        tail --pid=$(pidof PalServer-Linux-Test) -f 2>/dev/null
+        kill -SIGTERM $killpid
     fi
+    tail --pid=$killpid -f 2>/dev/null
 }
 
 trap 'term_handler' SIGTERM

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -18,11 +18,11 @@ if [ "${UPDATE_ON_BOOT}" = true ]; then
 fi
 
 term_handler() {
-    if [ ${RCON_ENABLED} = true ]; then
+    if [ "${RCON_ENABLED}" = true ]; then
         rcon-cli save
         rcon-cli shutdown 1
     else # Does not save
-        kill -SIGTERM $(pidof PalServer-Linux-Test)
+        kill -SIGTERM "$(pidof PalServer-Linux-Test)"
     fi
     tail --pid=$killpid -f 2>/dev/null
 }

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -21,8 +21,8 @@ term_handler() {
     if [ ${RCON_ENABLED} = true ]; then
         rcon-cli save
         rcon-cli shutdown 1
-    else # Not graceful
-        kill -SIGTERM $killpid
+    else # Does not save
+        kill -SIGTERM $(pidof PalServer-Linux-Test)
     fi
     tail --pid=$killpid -f 2>/dev/null
 }

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -17,4 +17,20 @@ if [ "${UPDATE_ON_BOOT}" = true ]; then
     su steam -c '/home/steam/steamcmd/steamcmd.sh +force_install_dir "/palworld" +login anonymous +app_update 2394010 validate +quit'
 fi
 
-./start.sh
+term_handler() {
+    rcon-cli shutdown 1
+    while true
+    do
+        rcon-cli info
+        if [ $? -ne 0 ]; then
+            break
+        fi
+        sleep 1 
+    done
+}
+
+trap 'term_handler' SIGTERM
+
+./start.sh &
+killpid="$!"
+wait $killpid


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Add in graceful stop

## Choices

* Using rcon was mentioned by @thijsvanloef in #62
* In the event rcon is not used then kill is used instead

## Test instructions

1. Run with `RCON_ENABLED=true`
2. Join the game and move to a different location in game
3. Stop the container with ctrl + c
4. Restart container and join game again to verify it saved where you ended
5. Repeat 1 - 3 with `RCON_ENABLED=false` NOTE: this does not save without rcon

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
