### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3'
 services:
    palworld:
       image: thijsvanloef/palworld-server-docker:latest


### PR DESCRIPTION
Added missing Version number for Docker Engine

## Context 

You receive an error if you try to run this without the Version number:

ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services: 'palworld'
* <!-- What do you want to achieve with this PR? -->

## Fix the issue

Simplest fix

## Test instructions

- New Linux Machine
- Run the following

```
sudo apt update
sudo apt upgrade -y
sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
echo "deb [signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
sudo apt update
sudo apt-get install -y docker-ce docker-ce-cli containerd.io
sudo apt-get install -y docker-compose
sudo useradd -m -s /bin/bash docker
sudo usermod -aG docker docker
su - docker
mkdir ~/palworld
cd ~/palworld
wget https://raw.githubusercontent.com/thijsvanloef/palworld-server-docker/main/docker-compose.yml
nano docker-compose.yml
docker-compose up -d
```


## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
