### PR TITLE
Support migrate from an existing server

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,29 @@ For a more detailed list of explanations of server settings go to: [shockbyte](h
 > If the `<mount_folder>/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini` is empty,
 > delete the file and restart the server, a new file with content will be created.
 
+## Migrate From Existing Server
+
+1. Find a directory which is named by game server name and contains all saved game data, usually it will at `~/Steam/steamapps/common/PalServer/Pal/Saved/SaveGames/0/`
+2. Make sure `migration/migrate.sh`, saved game data directory and mounted volume (e.g. `palworld/`) are in the same directory. Like this:
+    ```shell
+    ubuntu@VM-4-5-ubuntu:~/test-pal-migrate$ ll
+    total 24
+    drwxrwxr-x  4 ubuntu ubuntu 4096 Jan 26 03:31 ./
+    drwxr-x--- 12 ubuntu ubuntu 4096 Jan 26 03:31 ../
+    drwxr-xr-x  2 ubuntu ubuntu 4096 Jan 26 03:30 74406BE1D7B54114AA5984CCF1236865/
+    -rw-r--r--  1 ubuntu ubuntu  840 Jan 25 05:51 docker-compose.yml
+    -rw-rw-r--  1 ubuntu ubuntu  848 Jan 26 03:31 migrate.sh
+    drwxrwxr-x  7 ubuntu ubuntu 4096 Jan 26 03:31 palworld/
+    ```
+3. Run `migrate.sh` like this
+    ```shell
+    ./migrate.sh {CONTAINER_NAME} {SERVER_NAME}
+    ```
+   For example,
+    ```shell
+    ./migrate.sh test-pal-migrate 74406BE1D7B54114AA5984CCF1236865
+    ```
+
 ## Reporting Issues/Feature Requests
 
 Issues/Feature requests can be submitted by using [this link](https://github.com/thijsvanloef/palworld-server-docker/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -191,10 +191,13 @@ For a more detailed list of explanations of server settings go to: [shockbyte](h
     drwxrwxr-x  7 ubuntu ubuntu 4096 Jan 26 03:31 palworld/
     ```
 3. Run `migrate.sh` like this
+
     ```shell
     ./migrate.sh {CONTAINER_NAME} {SERVER_NAME}
     ```
+   
    For example,
+
     ```shell
     ./migrate.sh test-pal-migrate 74406BE1D7B54114AA5984CCF1236865
     ```

--- a/README.md
+++ b/README.md
@@ -176,32 +176,6 @@ For a more detailed list of explanations of server settings go to: [shockbyte](h
 > If the `<mount_folder>/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini` is empty,
 > delete the file and restart the server, a new file with content will be created.
 
-## Migrate From Existing Server
-
-1. Find a directory which is named by game server name and contains all saved game data, usually it will at `~/Steam/steamapps/common/PalServer/Pal/Saved/SaveGames/0/`
-2. Make sure `migration/migrate.sh`, saved game data directory and mounted volume (e.g. `palworld/`) are in the same directory. Like this:
-    ```shell
-    ubuntu@VM-4-5-ubuntu:~/test-pal-migrate$ ll
-    total 24
-    drwxrwxr-x  4 ubuntu ubuntu 4096 Jan 26 03:31 ./
-    drwxr-x--- 12 ubuntu ubuntu 4096 Jan 26 03:31 ../
-    drwxr-xr-x  2 ubuntu ubuntu 4096 Jan 26 03:30 74406BE1D7B54114AA5984CCF1236865/
-    -rw-r--r--  1 ubuntu ubuntu  840 Jan 25 05:51 docker-compose.yml
-    -rw-rw-r--  1 ubuntu ubuntu  848 Jan 26 03:31 migrate.sh
-    drwxrwxr-x  7 ubuntu ubuntu 4096 Jan 26 03:31 palworld/
-    ```
-3. Run `migrate.sh` like this
-
-    ```shell
-    ./migrate.sh {CONTAINER_NAME} {SERVER_NAME}
-    ```
-   
-   For example,
-
-    ```shell
-    ./migrate.sh test-pal-migrate 74406BE1D7B54114AA5984CCF1236865
-    ```
-
 ## Reporting Issues/Feature Requests
 
 Issues/Feature requests can be submitted by using [this link](https://github.com/thijsvanloef/palworld-server-docker/issues/new/choose).

--- a/migration/README.md
+++ b/migration/README.md
@@ -1,5 +1,7 @@
 # Migrate From Existing Server
 
+## Using the script
+
 > [!WARNING]
 > Use this script at your own risk, I am not responsible for dataloss!
 >
@@ -32,3 +34,14 @@
     ```shell
     ./migrate.sh test-pal-migrate 74406BE1D7B54114AA5984CCF1236865
     ```
+
+## Manually
+
+1. Copy the save from your old dedicated server to your new dedicated server.
+2. In the `PalServer\Pal\Saved\Config\LinuxServer\GameUserSettings.ini` file of the **new** server,
+   change the `DedicatedServerName` to match your save's folder name. For example,
+   if your save's folder name is `2E85FD38BAA792EB1D4C09386F3A3CDA`, the DedicatedServerName changes to
+   DedicatedServerName=`2E85FD38BAA792EB1D4C09386F3A3CDA`.
+3. Delete the entire new server save at `PalServer\Pal\Saved\SaveGames\0\<your_save_here>`,
+   and replace it with the folder from the old server.
+4. Restart the new server

--- a/migration/README.md
+++ b/migration/README.md
@@ -1,0 +1,25 @@
+# Migrate From Existing Server
+
+1. Find a directory which is named by game server name and contains all saved game data, usually it will at `~/Steam/steamapps/common/PalServer/Pal/Saved/SaveGames/0/`
+2. Make sure `migration/migrate.sh`, saved game data directory and mounted volume (e.g. `palworld/`) are in the same directory. Like this:
+    ```shell
+    ubuntu@VM-4-5-ubuntu:~/test-pal-migrate$ ll
+    total 24
+    drwxrwxr-x  4 ubuntu ubuntu 4096 Jan 26 03:31 ./
+    drwxr-x--- 12 ubuntu ubuntu 4096 Jan 26 03:31 ../
+    drwxr-xr-x  2 ubuntu ubuntu 4096 Jan 26 03:30 74406BE1D7B54114AA5984CCF1236865/
+    -rw-r--r--  1 ubuntu ubuntu  840 Jan 25 05:51 docker-compose.yml
+    -rw-rw-r--  1 ubuntu ubuntu  848 Jan 26 03:31 migrate.sh
+    drwxrwxr-x  7 ubuntu ubuntu 4096 Jan 26 03:31 palworld/
+    ```
+3. Run `migrate.sh` like this
+
+    ```shell
+    ./migrate.sh {CONTAINER_NAME} {SERVER_NAME}
+    ```
+
+   For example,
+
+    ```shell
+    ./migrate.sh test-pal-migrate 74406BE1D7B54114AA5984CCF1236865
+    ```

--- a/migration/README.md
+++ b/migration/README.md
@@ -1,7 +1,9 @@
 # Migrate From Existing Server
 
-1. Find a directory which is named by game server name and contains all saved game data, usually it will at `~/Steam/steamapps/common/PalServer/Pal/Saved/SaveGames/0/`
-2. Make sure `migration/migrate.sh`, saved game data directory and mounted volume (e.g. `palworld/`) are in the same directory. Like this:
+1. Find a directory which is named by game server name and contains all saved game data,
+   usually it will at `~/Steam/steamapps/common/PalServer/Pal/Saved/SaveGames/0/`
+3. Make sure `migration/migrate.sh`, saved game data directory and mounted volume (e.g. `palworld/`) are in the same directory. Like this:
+   
     ```shell
     ubuntu@VM-4-5-ubuntu:~/test-pal-migrate$ ll
     total 24
@@ -12,7 +14,8 @@
     -rw-rw-r--  1 ubuntu ubuntu  848 Jan 26 03:31 migrate.sh
     drwxrwxr-x  7 ubuntu ubuntu 4096 Jan 26 03:31 palworld/
     ```
-3. Run `migrate.sh` like this
+
+5. Run `migrate.sh` like this
 
     ```shell
     ./migrate.sh {CONTAINER_NAME} {SERVER_NAME}

--- a/migration/README.md
+++ b/migration/README.md
@@ -1,9 +1,15 @@
 # Migrate From Existing Server
 
+> [!WARNING]
+> Use this script at your own risk, I am not responsible for dataloss!
+>
+> Please make sure you always have a backup!
+
 1. Find a directory which is named by game server name and contains all saved game data,
    usually it will at `~/Steam/steamapps/common/PalServer/Pal/Saved/SaveGames/0/`
-3. Make sure `migration/migrate.sh`, saved game data directory and mounted volume (e.g. `palworld/`) are in the same directory. Like this:
-   
+2. Make sure `migration/migrate.sh`, saved game data directory and mounted volume
+   (e.g. `palworld/`) are in the same directory. Like this:
+
     ```shell
     ubuntu@VM-4-5-ubuntu:~/test-pal-migrate$ ll
     total 24
@@ -15,7 +21,7 @@
     drwxrwxr-x  7 ubuntu ubuntu 4096 Jan 26 03:31 palworld/
     ```
 
-5. Run `migrate.sh` like this
+3. Run `migrate.sh` like this
 
     ```shell
     ./migrate.sh {CONTAINER_NAME} {SERVER_NAME}

--- a/migration/migrate.sh
+++ b/migration/migrate.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+CONTAINER_NAME=$1
+MIGRATION_SERVER_NAME=$2
+
+if [ ! -d ./"${MIGRATION_SERVER_NAME}" ]; then
+  echo "can not find ${MIGRATION_SERVER_NAME} dir at current dir"
+  exit 1
+fi
+
+if [ ! -d ./palworld ]; then
+  echo "can not find palworld dir at current dir"
+  exit 1
+fi
+
+CONTAINER_ID=$(docker ps --filter name="${CONTAINER_NAME}" --format '{{.ID}}')
+
+echo "########## STOPPING CONTAINER ${CONTAINER_NAME} NOW ##########"
+docker stop "${CONTAINER_ID}"
+
+cp -r ./"${MIGRATION_SERVER_NAME}" ./palworld/Pal/Saved/SaveGames/0/"${MIGRATION_SERVER_NAME}"/
+
+sed -i "s/DedicatedServerName=.*/DedicatedServerName=${MIGRATION_SERVER_NAME}/" ./palworld/Pal/Saved/Config/LinuxServer/GameUserSettings.ini
+
+echo "########## STARTING CONTAINER ${CONTAINER_NAME} NOW ##########"
+docker start "${CONTAINER_ID}"
+
+


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

To solve #96 

I think `/palworld/Pal/Saved/Config/LinuxServer/GameUserSettings.ini` is generated after the service is started for the first time, so I can only write an additional script to facilitate migration.

After several experiments, the migration plan was determined to be successful.

## Test instructions

This script is also tested.

<img width="1245" alt="image" src="https://github.com/thijsvanloef/palworld-server-docker/assets/24605603/d6eb54b1-715a-49fd-ad52-eea880ee123e">

<img width="877" alt="image" src="https://github.com/thijsvanloef/palworld-server-docker/assets/24605603/2da6bd7e-d5f9-4754-80d8-50e5ab79e8fb">

<img width="784" alt="image" src="https://github.com/thijsvanloef/palworld-server-docker/assets/24605603/8b5a71d2-32d8-4719-87ab-168fb4c9c47f">

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
