### PR TITLE
Increase recommended disk size to 12GB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This Docker container has been tested and will work on both Linux (Ubuntu/Debian
 |----------|---------|------------------------------------------|
 | CPU      | 4 cores | 4+ cores                                 |
 | RAM      | 16GB    | Recommend over 32GB for stable operation |
-| Storage  | 4GB     | 10GB                                     |
+| Storage  | 4GB     | 12GB                                     |
 
 ## How to use
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,7 +24,7 @@ server:
     # -- Keeps helm from deleting the PVC. By default, helm does not delete pvcs.
     preventDelete: false
     # -- The size of the pvc storage.
-    size: 10Gi
+    size: 12Gi
     # -- The storage class name.
     storageClassName: ""
   # -- (dict) Define the parameters for the server image container
@@ -133,5 +133,3 @@ server:
       password: ""
       # -- (string) If not provided, a random server name will be generated with the "palworld_" prefix.
     server_name: ""
-
-

--- a/k8s/pvc.yaml
+++ b/k8s/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 12Gi


### PR DESCRIPTION
The steamcmd update requires an extra 2GB of free disk space. The container seems to be using around 8.7GB, which results in a steam update failure of `Error! App '2394010' state is 0x226 after update job.` since there isn't enough space to grab the new version in a 10GB disk. Bumping this to 12GB should result in ~3.4GB of free space, so there is a small buffer for future update size increases.

## Context <!-- markdownlint-disable MD041 -->

* Update documentation to help others who want to set up the container correctly to begin with.

## Test instructions

1. N/A - documentation update only

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
