### PR TITLE
updating STARTCOMMAND to array with += syntax and allowing spaces in …

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -76,4 +76,4 @@ EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
 echo "${STARTCOMMAND}"
-su steam -c "${STARTCOMMAND}"
+su steam -c "${STARTCOMMAND[@]}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -75,5 +75,5 @@ password: ${ADMIN_PASSWORD}
 EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
-echo "${STARTCOMMAND}"
+echo "${STARTCOMMAND[@]}"
 su steam -c "${STARTCOMMAND[@]}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,45 +1,45 @@
 #!/bin/bash
 
-STARTCOMMAND="./PalServer.sh"
+STARTCOMMAND=("./PalServer.sh")
 
 if [ -n "${PORT}" ]; then
-    STARTCOMMAND="${STARTCOMMAND} -port=${PORT}"
+    STARTCOMMAND+=("-port=${PORT}")
 fi
 
 if [ -n "${PLAYERS}" ]; then
-    STARTCOMMAND="${STARTCOMMAND} -players=${PLAYERS}"
+    STARTCOMMAND+=("-players=${PLAYERS}")
 fi
 
 if [ "${COMMUNITY}" = true ]; then
-    STARTCOMMAND="${STARTCOMMAND} EpicApp=PalServer"
+    STARTCOMMAND+=("EpicApp=PalServer")
 fi
 
 if [ -n "${PUBLIC_IP}" ]; then
-    STARTCOMMAND="${STARTCOMMAND} -publicip=${PUBLIC_IP}"
+    STARTCOMMAND+=("-publicip=${PUBLIC_IP}")
 fi
 
 if [ -n "${PUBLIC_PORT}" ]; then
-    STARTCOMMAND="${STARTCOMMAND} -publicport=${PUBLIC_PORT}"
+    STARTCOMMAND+=("-publicport=${PUBLIC_PORT}")
 fi
 
 if [ -n "${SERVER_NAME}" ]; then
-    STARTCOMMAND="${STARTCOMMAND} -servername=${SERVER_NAME}"
+    STARTCOMMAND+=("-servername=${SERVER_NAME}")
 fi
 
 if [ -n "${SERVER_PASSWORD}" ]; then
-    STARTCOMMAND="${STARTCOMMAND} -serverpassword=${SERVER_PASSWORD}"
+    STARTCOMMAND+=("-serverpassword=${SERVER_PASSWORD}")
 fi
 
 if [ -n "${ADMIN_PASSWORD}" ]; then
-    STARTCOMMAND="${STARTCOMMAND} -adminpassword=${ADMIN_PASSWORD}"
+    STARTCOMMAND+=("-adminpassword=${ADMIN_PASSWORD}")
 fi
 
 if [ -n "${QUERY_PORT}" ]; then
-    STARTCOMMAND="${STARTCOMMAND} -queryport=${QUERY_PORT}"
+    STARTCOMMAND+=("-queryport=${QUERY_PORT}")
 fi
 
 if [ "${MULTITHREADING}" = true ]; then
-    STARTCOMMAND="${STARTCOMMAND} -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS"
+    STARTCOMMAND+=("-useperfthreads" "-NoAsyncLoadingThread" "-UseMultithreadForDS")
 fi
 
 cd /palworld || exit


### PR DESCRIPTION
Updating to using array for STARTCOMMAND due to issues that `su steam -c "${STARTCOMMAND}"` can have with escaped quotes and spaces, also this will allow for spaces in server names and passwords

## Context <!-- markdownlint-disable MD041 -->

Allow users to use spaces in certain environment variables

## Choices

- Better handling of spaces in program arguments that should allow them, such as server name and passwords

## Test instructions

1. Run the server with this change and have spaces in the passwords or in the server name

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README. 
there is no mention spaces aren't supported, so this will just be helpful overall
* [x] I've not introduced breaking changes.
