### PR TITLE
Fix: README.md docker-compose.yml link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Keep in mind that you'll need to change the [environment variables](#environment
 
 ### Docker Compose
 
-This repository includes an example [docker-compose.yml](example/docker-compose.yml) file you can use to setup your server.
+This repository includes an example [docker-compose.yml](/docker-compose.yml) file you can use to setup your server.
 
 ```yml
 services:


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Fixed the link to go to docker-compose.yml within `README.md` being misplaced and going to the wrong place.

## Choices

* Fixed `README.md`

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [v] I have performed a self-review of my code
* [v] I've added documentation about this change to the README.
* [v] I've not introduced breaking changes.
