### PR TITLE
Add: README.md Environment variable important statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ It is highly recommended you set the following environment values before startin
 
 *** Required for docker stop to save and gracefully close the server
 
+> [!IMPORTANT]
+> Boolean values used in environment variables are case sensitive because they are used in the shell script.
+>
+> They must be set using exactly true or false for the option to take effect.
+
 ### Game Ports
 
 | Port  | Info             |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ It is highly recommended you set the following environment values before startin
 > [!IMPORTANT]
 > Boolean values used in environment variables are case sensitive because they are used in the shell script.
 >
-> They must be set using exactly true or false for the option to take effect.
+> They must be set using exactly `true` or `false` for the option to take effect.
 
 ### Game Ports
 


### PR DESCRIPTION
Added caveats for Boolean type environment variable options.

## Context <!-- markdownlint-disable MD041 -->

Added caveats for Boolean type environment variable options.

## Choices

In fact, in my own experience, where case sensitivity prevented the option from being applied correctly, the cautionary note.

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [v] I have performed a self-review of my code
* [v] I've added documentation about this change to the README.
* [v] I've not introduced breaking changes.
