### PR TITLE
modify deployment and chart for opionated deployment

### DIFF
--- a/chart/templates/deployments.yaml
+++ b/chart/templates/deployments.yaml
@@ -8,9 +8,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: "{{ .Release.Name }}-server"
+  strategy:
+    type: "{{ .Values.server.strategy }}"
   template:
-    strategy:
-      type: "{{ .Values.server.strategy }}"
     metadata:
       annotations:
         {{- with .Values.server.annotations }}

--- a/chart/templates/deployments.yaml
+++ b/chart/templates/deployments.yaml
@@ -9,6 +9,8 @@ spec:
     matchLabels:
       app.kubernetes.io/component: "{{ .Release.Name }}-server"
   template:
+    strategy:
+      type: "{{ .Values.server.strategy }}"
     metadata:
       annotations:
         {{- with .Values.server.annotations }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,6 +56,8 @@ server:
     - name: rcon
       containerPort: 25575
       protocol: UDP
+  # -- (string) Change the deployment strategy
+  strategy: Recreate
 
   # -- (dict) Change the service configuration.
   # If you change those, make sure to change the server.config and server.ports accordingly.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   name: palworld-server
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: palworld-server


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

It is relatively unsafe with the way Palworld handles it's server terminations to leave the default deployment setting of RollingUpdate. Switching to Recreate ensures the old pod is terminated and not writting to the volume while the new pod is starting.

## Choices

Opionated change is done in the suggested deployment yaml and the chart sets Recreate by default but leave it a configurable option.

## Test instructions

Deployed to my local cluster, valiadate that deployment still works and that it terminates the pod prior to scheduling the new pod.

## Checklist before requesting a review

* [X] I have performed a self-review of my code
* [X] I've added documentation about this change to the README.
* [X] I've not introduced breaking changes.
