### PR TITLE
Make volume mount hierarchy consistent, implement tickrate

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -21,6 +21,9 @@ metadata:
   name: palworld-settings
 data:
   PalWorldSettings.ini: >-
+    [/Script/OnlineSubsystemUtils.IpNetDriver]
+    NetServerMaxTickRate=60
+    
     [/Script/Pal.PalGameWorldSettings]
     
     OptionSettings=(

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -37,8 +37,8 @@ spec:
           volumeMounts:
             - mountPath: /palworld
               name: datadir
-            - name: palworld-settings
-              mountPath: /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+            - mountPath: /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+              name: palworld-settings
               subPath: PalWorldSettings.ini
       volumes:
       - name: datadir


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

For me, volume mount was not updating despite destroying the pod and spawning a new one.

Changing the hierarchy to be consistent with the data dir mount fixed this when redeploying despite k8s claiming the yaml was equivalent.

My goal was to implement changes to the tickrate. This exposes tickrate as a setting.

## Choices

Resolved my issue. Server subjectively seems more active.

## Test instructions

kubectl exec <pod name> -- cat /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini

Before: default contents despite configmap looking correct

After: reflects custom configmap with tickrate change

## Checklist before requesting a review

* [✅] I have performed a self-review of my code
* [✅] I've added documentation about this change to the README.
* [✅] I've not introduced breaking changes.
