### PR TITLE
Added fix for blank PalWorld Settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,6 @@ Please keep in mind that the ENV variables will always overwrite the changes mad
 
 For a more detailed list of explanations of server settings go to: [shockbyte](https://shockbyte.com/billing/knowledgebase/1189/How-to-Configure-your-Palworld-server.html)
 
-> [!TIP]
-> If the `<mount_folder>/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini` is empty,
-> delete the file and restart the server, a new file with content will be created.
 
 ## Reporting Issues/Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ Please keep in mind that the ENV variables will always overwrite the changes mad
 
 For a more detailed list of explanations of server settings go to: [shockbyte](https://shockbyte.com/billing/knowledgebase/1189/How-to-Configure-your-Palworld-server.html)
 
-
 ## Reporting Issues/Feature Requests
 
 Issues/Feature requests can be submitted by using [this link](https://github.com/thijsvanloef/palworld-server-docker/issues/new/choose).

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -46,7 +46,8 @@ cd /palworld || exit
 
 printf "\e[0;32m*****CHECKING FOR EXISTING CONFIG*****\e[0m\n"
 
-if [ ! "$(grep -s '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini)" ]; then
+# This will always overwrite
+if [ ! "$(grep -sq '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini)" ]; then
 
     printf "\e[0;32m*****GENERATING CONFIG*****\e[0m\n"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -46,7 +46,7 @@ cd /palworld || exit
 
 printf "\e[0;32m*****CHECKING FOR EXISTING CONFIG*****\e[0m\n"
 
-if [ ! -f /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini ]; then
+if [ ! -f /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini ] || [ -z $(grep '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini) ]; then
 
     printf "\e[0;32m*****GENERATING CONFIG*****\e[0m\n"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -46,7 +46,7 @@ cd /palworld || exit
 
 printf "\e[0;32m*****CHECKING FOR EXISTING CONFIG*****\e[0m\n"
 
-if [ $(grep -qs '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini) ]; then
+if [ ! "$(grep -s '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini)" ]; then
 
     printf "\e[0;32m*****GENERATING CONFIG*****\e[0m\n"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -46,7 +46,7 @@ cd /palworld || exit
 
 printf "\e[0;32m*****CHECKING FOR EXISTING CONFIG*****\e[0m\n"
 
-if [ ! -f /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini ] || [ -z $(grep '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini) ]; then
+if [ $(grep -qs '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini) ]; then
 
     printf "\e[0;32m*****GENERATING CONFIG*****\e[0m\n"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -46,8 +46,9 @@ cd /palworld || exit
 
 printf "\e[0;32m*****CHECKING FOR EXISTING CONFIG*****\e[0m\n"
 
-# This will always overwrite
-if [ ! "$(grep -sq '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini)" ]; then
+# Check if PalWorldSettings.ini exists and it not blank
+grep -s '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+if [ ! $? ]; then
 
     printf "\e[0;32m*****GENERATING CONFIG*****\e[0m\n"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -46,9 +46,8 @@ cd /palworld || exit
 
 printf "\e[0;32m*****CHECKING FOR EXISTING CONFIG*****\e[0m\n"
 
-# Check if PalWorldSettings.ini exists and it not blank
-grep -s '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
-if [ ! $? ]; then
+# shellcheck disable=SC2143
+if [ ! "$(grep -s '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini)" ]; then
 
     printf "\e[0;32m*****GENERATING CONFIG*****\e[0m\n"
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Removes the need to manually delete the PalWorldSettings.ini file if it is blank to trigger a copy of the default file at next startup.

## Choices

* Using grep since that is already included in the image.

## Test instructions

1. Start the container without `:/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini`
2. Verify the file is created
3. Start the container with an empty (zero bytes, you can use touch) `:/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini`
4. Verify the file is overwritten
5. Start container with a valid `:/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini` (Ideally modify a value)
6. Verify the file not overwritten

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
