### PR TITLE
fixing startcmd command

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -75,5 +75,5 @@ password: ${ADMIN_PASSWORD}
 EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
-echo "${STARTCOMMAND[@]}"
-su steam -c "${STARTCOMMAND[@]}"
+echo "bash -c '${STARTCOMMAND[@]}'"
+su steam -c "bash -c '${STARTCOMMAND[@]}'"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

support env var spaces

## Choices
This ensures that the entire command string is correctly interpreted as a single argument to bash.

## Test instructions

local docker compose

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
^for real this time
![image](https://github.com/thijsvanloef/palworld-server-docker/assets/9669831/00b425a5-85ab-4181-9c63-dc6e2859d5af)
