### PR TITLE
Update start script

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -75,5 +75,6 @@ password: ${ADMIN_PASSWORD}
 EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
-echo "bash -c '${STARTCOMMAND[@]}"
-su steam -c "bash -c '${STARTCOMMAND[@]}'"
+echo "bash -c '${STARTCOMMAND[*]}'"
+su steam -c "bash -c '${STARTCOMMAND[*]}'"
+

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -75,5 +75,5 @@ password: ${ADMIN_PASSWORD}
 EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
-echo "${STARTCOMMAND[@]}"
-su steam -c "${STARTCOMMAND[@]}"
+echo "bash -c '${STARTCOMMAND[@]}'"
+su steam -c "bash -c '${STARTCOMMAND[@]}'"


### PR DESCRIPTION
Updating to using array for STARTCOMMAND due to issues that `su steam -c "${STARTCOMMAND}"` can have with escaped quotes and spaces, also this will allow for spaces in server names and passwords

## Context <!-- markdownlint-disable MD041 -->

Allow users to use spaces in environment variables

## Choices

- Better handling of spaces in program arguments that should allow them, such as server name and passwords

## Test instructions

1. Run the server with this change and have spaces in the passwords or in the server name

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README. 
there is no mention spaces aren't supported, so this will just be helpful overall
* [x] I've not introduced breaking changes.
fully tested this time instead of just testing printing the startcmd. sorry about that! here's proof:

![image](https://github.com/thijsvanloef/palworld-server-docker/assets/9669831/d52ba88a-732d-41a8-bae4-2a42792f7098)
