### PR TITLE
- Modified the chart, now the healthz container/service port is optional

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.0.0
+version: 0.0.1
 description: This chart can provide an rAthena emulator installation on a Kubernetes cluster.
 type: application
 keywords:

--- a/chart/VALUES_SUMMARY.md
+++ b/chart/VALUES_SUMMARY.md
@@ -1,6 +1,8 @@
 # palworld
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational)
+![Type: application](https://img.shields.io/badge/Type-application-informational)
+![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational)
 
 This chart can provide an rAthena emulator installation on a Kubernetes cluster.
 

--- a/chart/VALUES_SUMMARY.md
+++ b/chart/VALUES_SUMMARY.md
@@ -1,8 +1,6 @@
 # palworld
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square)
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 This chart can provide an rAthena emulator installation on a Kubernetes cluster.
 
@@ -50,18 +48,18 @@ This chart can provide an rAthena emulator installation on a Kubernetes cluster.
 | server.service | dict |  | Change the service configuration. If you change those, make sure to change the server.config and server.ports accordingly. |
 | server.service.annotations | object | `{}` | Additional annotations to the resources |
 | server.service.enabled | bool | `true` | Enables the creation of the service component. |
+| server.service.healthz | dict | `{"enabled":false,"name":"healthz","port":80,"protocol":"TCP","targetPort":80}` | The "healthz" definition . Use if you need to create a TCP health check for load balancers on cloud services. |
 | server.service.labels | object | `{}` | Additional labels to the resources |
 | server.service.ports | dict |  | Change the ports to be mapped to the service. If you change those, make sure to change the server.config and server.ports accordingly. |
 | server.service.ports[0] | dict | `{"name":"game","port":8211,"protocol":"UDP","targetPort":8211}` | The "game" port definition. If you change this, make sure to change the server.ports.game and server.config.port accordingly. |
 | server.service.ports[1] | dict | `{"name":"query","port":27015,"protocol":"UDP","targetPort":27015}` | The "query" port definition . If you change this, make sure to change the server.ports.query and server.config.query_port accordingly. |
 | server.service.ports[2] | dict | `{"name":"rcon","port":25575,"protocol":"UDP","targetPort":25575}` | The "rcon" port definition . If you change this, make sure to change the server.ports.rcon and server.config.rcon.port accordingly. |
-| server.service.ports[3] | dict | `{"name":"healthz","port":80,"protocol":"TCP","targetPort":80}` | The "healthz" port definition . Used only to create a health check for load balancers on cloud services. |
 | server.service.type | string | `"LoadBalancer"` | The type of service to be created. |
-| server.storage | dict | `{"external":false,"externalName":"","preventDelete":false,"size":"10Gi","storageClassName":""}` | Define some parameters for the storage volume |
+| server.storage | dict | `{"external":false,"externalName":"","preventDelete":false,"size":"12Gi","storageClassName":""}` | Define some parameters for the storage volume |
 | server.storage.external | bool | `false` | Define if it will use an existing PVC containing the installation data. |
 | server.storage.externalName | bool | `""` | The external PVC name to use. |
 | server.storage.preventDelete | bool | `false` | Keeps helm from deleting the PVC. By default, helm does not delete pvcs. |
-| server.storage.size | string | `"10Gi"` | The size of the pvc storage. |
+| server.storage.size | string | `"12Gi"` | The size of the pvc storage. |
 | server.storage.storageClassName | string | `""` | The storage class name. |
 
 ----------------------------------------------

--- a/chart/templates/deployments.yaml
+++ b/chart/templates/deployments.yaml
@@ -26,6 +26,7 @@ spec:
         {{- end }}
     spec:
       containers:
+        {{ if .Values.server.service.healthz.enabled }}
         - name: healthz
           image: "chussenot/tiny-server:latest"
           imagePullPolicy: {{ .Values.server.image.imagePullPolicy }}
@@ -33,6 +34,7 @@ spec:
             - name: healthz
               containerPort: 80
               protocol: TCP
+        {{ end }}
         - name: server
           image: "{{ .Values.server.image.name }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.server.image.imagePullPolicy }}

--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -22,6 +22,12 @@ spec:
   selector:
     app.kubernetes.io/component: "{{ .Release.Name }}-server"
   ports:
+    {{ if .Values.server.service.healthz.enabled }}
+    - name: {{ .Values.server.service.healthz.name }}
+      port: {{ .Values.server.service.healthz.port }}
+      protocol: {{ .Values.server.service.healthz.protocol }}
+      targetPort: {{ .Values.server.service.healthz.targetPort }}
+    {{ end }}
     {{- with .Values.server.service.ports }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -69,6 +69,14 @@ server:
     labels: { }
     # -- (string) The type of service to be created.
     type: LoadBalancer
+    # -- (dict) The "healthz" definition .
+    # Use if you need to create a TCP health check for load balancers on cloud services.
+    healthz:
+      enabled: false
+      name: healthz
+      port: 80
+      protocol: TCP
+      targetPort: 80
     # -- (dict) Change the ports to be mapped to the service.
     # If you change those, make sure to change the server.config and server.ports accordingly.
     # @notationType -- bigValue
@@ -91,12 +99,6 @@ server:
         port: 25575
         protocol: UDP
         targetPort: 25575
-      # -- (dict) The "healthz" port definition .
-      # Used only to create a health check for load balancers on cloud services.
-      - name: healthz
-        port: 80
-        protocol: TCP
-        targetPort: 80
   # -- (dict) Change the game server configuration.
   # If you change those, make sure to change the service.ports and server.ports accordingly.
   # Those are directly connected with the container image, providing multiple environment variables to the scripts.


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Now deploying the healthz container and service port is optional;

## Choices

* To avoid conflicts with multiples cloud providers and different load balancers provisioning/types

## Test instructions

1. Git clone the repo;
2. Install Helm client and check if you have access to a Kubernetes cluster (tested on v1.29);
3. Create your values.override.yaml file and add the properties that are pertinent to your cluster;
4. Run the following command:
5. helm install --create-namespace --namespace palworld palworld chart/ --values values.override.yaml
6. The healthz container should not be created by default, the service should not have a 80/tcp port mapped

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
