### PR TITLE
Minimize Root Processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget -q https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz -O - | tar -xz && \
     mv rcon-0.10.3-amd64_linux/rcon /usr/bin/rcon-cli && \
-    ln -s /home/steam/server/rcon.yaml /root/rcon.yaml && \
     rmdir /tmp/dumps
 
 ENV PORT= \
@@ -33,8 +32,8 @@ ENV PORT= \
     SERVER_DESCRIPTION=
 
 COPY ./scripts/* /home/steam/server/
-RUN chmod u+x /home/steam/server/init.sh /home/steam/server/start.sh /home/steam/server/backup.sh && \
-    ln -s /home/steam/server/backup.sh /usr/local/bin/backup
+RUN chmod +x /home/steam/server/init.sh /home/steam/server/start.sh /home/steam/server/backup.sh && \
+    mv /home/steam/server/backup.sh /usr/local/bin/backup
 
 WORKDIR /home/steam/server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget -q https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz -O - | tar -xz && \
-    mv rcon-0.10.3-amd64_linux/rcon /usr/bin/rcon-cli
+    mv rcon-0.10.3-amd64_linux/rcon /usr/bin/rcon-cli && \
+    ln -s /home/steam/server/rcon.yaml /root/rcon.yaml
 
 ENV PORT= \
     PUID=1000 \
@@ -31,8 +32,8 @@ ENV PORT= \
     SERVER_DESCRIPTION=
 
 COPY ./scripts/* /home/steam/server/
-RUN chmod +x /home/steam/server/init.sh /home/steam/server/start.sh /home/steam/server/backup.sh && \
-    mv /home/steam/server/backup.sh /usr/local/bin/backup
+RUN chmod u+x /home/steam/server/init.sh /home/steam/server/start.sh /home/steam/server/backup.sh && \
+    ln -s /home/steam/server/backup.sh /usr/local/bin/backup
 
 WORKDIR /home/steam/server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget -q https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz -O - | tar -xz && \
     mv rcon-0.10.3-amd64_linux/rcon /usr/bin/rcon-cli && \
-    ln -s /home/steam/server/rcon.yaml /root/rcon.yaml
+    ln -s /home/steam/server/rcon.yaml /root/rcon.yaml && \
+    rmdir /tmp/dumps
 
 ENV PORT= \
     PUID=1000 \

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -9,4 +9,8 @@ FILE_PATH="/palworld/backups/palworld-save-${DATE}.tar.gz"
 cd /palworld/Pal/ || exit
 
 tar -zcf "$FILE_PATH" "Saved/"
+
+if [ $(id -u) -eq 0 ]; then
+        chown steam:steam "$FILE_PATH"
+fi
 echo "backup created at $FILE_PATH"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -13,4 +13,5 @@ tar -zcf "$FILE_PATH" "Saved/"
 if [ "$(id -u)" -eq 0 ]; then
         chown steam:steam "$FILE_PATH"
 fi
+
 echo "backup created at $FILE_PATH"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -10,7 +10,7 @@ cd /palworld/Pal/ || exit
 
 tar -zcf "$FILE_PATH" "Saved/"
 
-if [ $(id -u) -eq 0 ]; then
+if [ "$(id -u)" -eq 0 ]; then
         chown steam:steam "$FILE_PATH"
 fi
 echo "backup created at $FILE_PATH"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -10,12 +10,7 @@ else
 fi
 
 mkdir -p /palworld/backups
-chown -R steam:steam /palworld
-
-if [ "${UPDATE_ON_BOOT}" = true ]; then
-    printf "\e[0;32m*****STARTING INSTALL/UPDATE*****\e[0m\n"
-    su steam -c '/home/steam/steamcmd/steamcmd.sh +force_install_dir "/palworld" +login anonymous +app_update 2394010 validate +quit'
-fi
+chown -R steam:steam /palworld /home/steam/
 
 term_handler() {
     if [ "${RCON_ENABLED}" = true ]; then
@@ -29,6 +24,7 @@ term_handler() {
 
 trap 'term_handler' SIGTERM
 
-./start.sh &
+su steam -c ./start.sh &
+# Process ID of su
 killpid="$!"
 wait $killpid

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -85,6 +85,6 @@ default:
 EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
-echo "bash -c '${STARTCOMMAND[@]}'"
+echo "bash -c '${STARTCOMMAND[*]}'"
 "${STARTCOMMAND[@]}"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -61,7 +61,7 @@ if [ ! "$(grep -s '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorld
     printf "\e[0;32m*****GENERATING CONFIG*****\e[0m\n"
 
     # Server will generate all ini files after first run.
-    su steam -c "timeout --preserve-status 15s ./PalServer.sh 1> /dev/null "
+    timeout --preserve-status 15s ./PalServer.sh 1> /dev/null
 
     # Wait for shutdown
     sleep 5

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "${UPDATE_ON_BOOT}" = true ]; then
+    printf "\e[0;32m*****STARTING INSTALL/UPDATE*****\e[0m\n"
+    /home/steam/steamcmd/steamcmd.sh +force_install_dir "/palworld" +login anonymous +app_update 2394010 validate +quit
+fi
+
 STARTCOMMAND=("./PalServer.sh")
 
 if [ -n "${PORT}" ]; then
@@ -81,5 +86,5 @@ EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
 echo "bash -c '${STARTCOMMAND[*]}'"
-su steam -c "bash -c '${STARTCOMMAND[*]}'"
+"${STARTCOMMAND[@]}"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -85,6 +85,6 @@ default:
 EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
-echo "bash -c '${STARTCOMMAND[*]}'"
+echo "bash -c '${STARTCOMMAND[@]}'"
 "${STARTCOMMAND[@]}"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -85,6 +85,6 @@ default:
 EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"
-echo "bash -c '${STARTCOMMAND[*]}'"
+echo "${STARTCOMMAND[*]}"
 "${STARTCOMMAND[@]}"
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Currently you start the container as root and during the start up process everything is ran as root except the command with `su`.
![image](https://github.com/thijsvanloef/palworld-server-docker/assets/18587674/c640cf61-4b0d-4c6b-bb93-3fbd8e332b97)

* Currently when backups are created they are created and owned by root however on next boot the permission is changed to steam:steam

* When starting with a PUID or PGID that is not 1000 you get the following error: `/tmp/dumps is not owned by us - delete and recreate`
```
palworld-server-test  | *****STARTING INSTALL/UPDATE*****
palworld-server-test  | tid(22) burning pthread_key_t == 0 so we never use it
palworld-server-test  | Redirecting stderr to '/home/steam/Steam/logs/stderr.txt'
palworld-server-test  | Logging directory: '/home/steam/Steam/logs'
palworld-server-test  | /tmp/dumps is not owned by us - delete and recreate
palworld-server-test  | [  0%] Checking for available updates..
```

* Currently When starting with a PGID that is not 1000 then /home/steam/ has the group 1000 instead of steam.

## Choices

* Overall trying to reduce having to run as root. 
* Moved all commands which needed `su` to start.sh
* Other commands in start.sh should be ran as steam anyways
* Everything in start.sh should only need to be ran as steam user

## Test instructions

**Unless explicitly stated your PUID or PGID should not be 0 for testing**

![image](https://github.com/thijsvanloef/palworld-server-docker/assets/18587674/5fcb2b03-0c2c-40ab-b24c-b3ade4ecd244)
1. Start container with a PGID that is neither 0 or 1000
    1.  verify you do not get this error: `/tmp/dumps is not owned by us - delete and recreate`
    2.  verify /home/steam is owned by steam:steam: `docker exec palworld-server bash -c "ls -ll /home/steam"`
2. After the server has finished booting use top to verify the only processes running as root are init.sh, su, and top: `docker exec -t palworld-server top`
3. Run a backup as root and verify that the file is owned by steam:steam: `docker exec palworld-server bash -c "backup && ls -l /palworld/backups/"`
4. Run a backup as steam and verify that the file is owned by steam:steam: `docker exec -u steam palworld-server bash -c "backup && ls -l /palworld/backups/"`
5. Test rcon-cli as root: `docker exec -it palworld-server-test rcon-cli`
6. Test rcon-cli as steam: `docker exec -it -u steam palworld-server-test rcon-cli`
7. Verify you don't get this message `/tmp/dumps is not owned by us - delete and recreate` when:
    1. Start container with a PGID that is 0
    2. Start container with a PUID that is 0
    3. Start container with a PUID & PGID that is 0
8. Verify you still get this message `Running as root is not supported, please fix your PUID and PGID!` when:
    1. Start container with a PGID that is 0
    2. Start container with a PUID that is 0
    3. Start container with a PUID & PGID that is 0

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
