### PR TITLE
Updated readme to explain when the settings can be modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,12 @@ The server will run a save before the backup if rcon is enabled.
 
 When the server starts, a `PalWorldSettings.ini` file will be created in the following location: `<mount_folder>/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini`
 
-Any changes made there will be applied to the Server on next boot.
+Any changes made while the server is live will be overridden.
 
 Please keep in mind that the ENV variables will always overwrite the changes made to `PalWorldSettings.ini`.
+
+> [!IMPORTANT]
+> Changes can only be made to `PalWorldSettings.ini` while the server is off.
 
 For a more detailed list of explanations of server settings go to: [shockbyte](https://shockbyte.com/billing/knowledgebase/1189/How-to-Configure-your-Palworld-server.html)
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Many people attempt to edit `PalWorldSettings.ini` while the server is live and rebooting causing the changes to be overwritten. #29 #161 
*  This will explain you should only modify `PalWorldSettings.ini` while the server is off.

## Choices

* Added to readme

## Test instructions

1. Verify readme makes sense.
2. Start container and wait for server to start then stop it
3. Modify `PalWorldSettings.ini` 
4. Start container and wait for server to start
5. Verify `PalWorldSettings.ini` still has your changes
6. Modify `PalWorldSettings.ini` again
7. Stop the server
8. Verify the file is reverted

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
