### PR TITLE
Add initial GitHub pages 

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+name: Pages
+
+on:
+  push:
+    branches: ["gh-pages"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: "."
+
+      - name: Deploy - Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head> </head>
+  <body>
+    Index <a href="index.yaml">index.yaml</a>
+  </body>
+</html>


### PR DESCRIPTION
# Motivations
A helm repository, in GitHub pages

# Modifications
- Add a workflow to publish the `gh-pages` branch to GitHub pages on Push
- Add `index.html` which simply links to the helm repository `index.yaml` (When it gets created by a release)

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
