### PR TITLE
String escaping with spaces

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,19 +12,19 @@ if [ -n "${PORT}" ]; then
 fi
 
 if [ -n "${SERVER_NAME}" ]; then
-    STARTCOMMAND+=("-servername=${SERVER_NAME}")
+    STARTCOMMAND+=("-servername=\"${SERVER_NAME}\"")
 fi
 
 if [ -n "${SERVER_DESCRIPTION}" ]; then
-    STARTCOMMAND+=("-serverdescription=${SERVER_DESCRIPTION}")
+    STARTCOMMAND+=("-serverdescription=\"${SERVER_DESCRIPTION}\"")
 fi
 
 if [ -n "${SERVER_PASSWORD}" ]; then
-    STARTCOMMAND+=("-serverpassword=${SERVER_PASSWORD}")
+    STARTCOMMAND+=("-serverpassword=\"${SERVER_PASSWORD}\"")
 fi
 
 if [ -n "${ADMIN_PASSWORD}" ]; then
-    STARTCOMMAND+=("-adminpassword=${ADMIN_PASSWORD}")
+    STARTCOMMAND+=("-adminpassword=\"${ADMIN_PASSWORD}\"")
 fi
 
 if [ -n "${QUERY_PORT}" ]; then


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

This fixes https://github.com/thijsvanloef/palworld-server-docker/issues/197

## Choices

Quote strings with spaces

## Test instructions

1. Create a new server with `SERVER_NAME` or `SERVER_DESCRIPTION` with spaces.
2. Check the generated ini config

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
