### PR TITLE
Add initial artifacthub-repo.yml

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,3 +1,4 @@
-repositoryID: '' # Blank for now
+repositoryID: 32c45b50-f5e4-4e14-a0db-96213c6657ab
 owners:
 - name: thijsvanloef
+- name: Twinki14

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,5 @@
 repositoryID: 767e1fda-67f3-422e-98ef-3774a2a840a6
 owners:
 - name: thijsvanloef
+  email: thijs@loef.dev
 - name: Twinki14

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,4 @@
-repositoryID: 32c45b50-f5e4-4e14-a0db-96213c6657ab
+repositoryID: 767e1fda-67f3-422e-98ef-3774a2a840a6
 owners:
 - name: thijsvanloef
 - name: Twinki14

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,1 @@
+repositoryID: ''

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,1 +1,3 @@
-repositoryID: ''
+repositoryID: '' # Blank for now
+owners:
+- name: thijsvanloef


### PR DESCRIPTION
# Motivations
Our helm chart should be good to go to put on artifact hub, https://artifacthub.io/

# Modifications
- Add `artifacthub-repo.yml` to `gh-pages`, which registers our helm chart to be picked up by artifact-hub