### PR TITLE
Fix incorrect environment variable handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ services:
          - PGID=1000
          - PORT=8211 # Optional but recommended
          - PLAYERS=16 # Optional but recommended
-         - SERVER_PASSWORD="worldofpals" # Optional but recommended
+         - SERVER_PASSWORD=worldofpals # Optional but recommended
          - MULTITHREADING=true
          - RCON_ENABLED=true
          - RCON_PORT=25575
          - TZ=UTC
-         - ADMIN_PASSWORD="adminPasswordHere"
+         - ADMIN_PASSWORD=adminPasswordHere
          - COMMUNITY=false  # Enable this if you want your server to show up in the community servers tab, USE WITH SERVER_PASSWORD!
-         - SERVER_NAME="World of Pals"
-         - SERVER_DESCRIPTION="Awesome World of Pal"
+         - SERVER_NAME=World of Pals
+         - SERVER_DESCRIPTION=palworld-server-docker by Thijs van Loef
       volumes:
          - ./palworld:/palworld/
 ```
@@ -108,11 +108,11 @@ docker run -d \
     -e RCON_ENABLED=true \
     -e RCON_PORT=25575 \
     -e TZ=UTC \
-    -e ADMIN_PASSWORD="adminPasswordHere" \
-    -e SERVER_PASSWORD="worldofpals" \
+    -e ADMIN_PASSWORD=adminPasswordHere \
+    -e SERVER_PASSWORD=worldofpals \
     -e COMMUNITY=false \
-    -e SERVER_NAME="World of Pals" \
-    -e SERVER_DESCRIPTION="Awesome World of Pal" \
+    -e SERVER_NAME=World of Pals \
+    -e SERVER_DESCRIPTION=palworld-server-docker by Thijs van Loef \
     --restart unless-stopped \
     --stop-timeout 30 \
     thijsvanloef/palworld-server-docker:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,14 @@ services:
          - PGID=1000
          - PORT=8211 # Optional but recommended
          - PLAYERS=16 # Optional but recommended
-         - SERVER_PASSWORD="worldofpals" # Optional but recommended
+         - SERVER_PASSWORD=worldofpals # Optional but recommended
          - MULTITHREADING=true
          - RCON_ENABLED=true
          - RCON_PORT=25575
          - TZ=UTC
-         - ADMIN_PASSWORD="adminPasswordHere"
+         - ADMIN_PASSWORD=adminPasswordHere
          - COMMUNITY=false  # Enable this if you want your server to show up in the community servers tab, USE WITH SERVER_PASSWORD!
-         - SERVER_NAME="World of Pals"
-         - SERVER_DESCRIPTION=""
+         - SERVER_NAME=World of Pals
+         - SERVER_DESCRIPTION=palworld-server-docker by Thijs van Loef
       volumes:
          - ./palworld:/palworld/

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -40,27 +40,36 @@ if [ ! "$(grep -s '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorld
     cp /palworld/DefaultPalWorldSettings.ini /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 
+escape_sed() {
+    printf '%s\n' "$1" | sed -e 's:[][\/.^$*]:\\&:g'
+}
+
 if [ -n "${SERVER_NAME}" ]; then
+    SERVER_NAME=$(escape_sed "$SERVER_NAME" | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/")
     echo "SERVER_NAME=${SERVER_NAME}"
-    sed -E -i "s/ServerName=\"[^\"]*\"/ServerName=$SERVER_NAME/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    sed -E -i "s/ServerName=\"[^\"]*\"/ServerName=\"$SERVER_NAME\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${SERVER_DESCRIPTION}" ]; then
+    SERVER_DESCRIPTION=$(escape_sed "$SERVER_DESCRIPTION" | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/")
     echo "SERVER_DESCRIPTION=${SERVER_DESCRIPTION}"
-    sed -E -i "s/ServerDescription=\"[^\"]*\"/ServerDescription=$SERVER_DESCRIPTION/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    sed -E -i "s/ServerDescription=\"[^\"]*\"/ServerDescription=\"$SERVER_DESCRIPTION\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${SERVER_PASSWORD}" ]; then
+    SERVER_PASSWORD=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$SERVER_PASSWORD")
     echo "SERVER_PASSWORD=${SERVER_PASSWORD}"
-    sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=$SERVER_PASSWORD/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"$SERVER_PASSWORD\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${ADMIN_PASSWORD}" ]; then
+    ADMIN_PASSWORD=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$ADMIN_PASSWORD")
     echo "ADMIN_PASSWORD=${ADMIN_PASSWORD}" 
-    sed -E -i "s/AdminPassword=\"[^\"]*\"/AdminPassword=$ADMIN_PASSWORD/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    sed -E -i "s/AdminPassword=\"[^\"]*\"/AdminPassword=\"$ADMIN_PASSWORD\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${PLAYERS}" ]; then
     echo "PLAYERS=${PLAYERS}"
     sed -E -i "s/ServerPlayerMaxNum=[0-9]*/ServerPlayerMaxNum=$PLAYERS/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${PUBLIC_IP}" ]; then
+    PUBLIC_IP=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$PUBLIC_IP")
     echo "PUBLIC_IP=${PUBLIC_IP}"
     sed -E -i "s/PublicIP=\"[^\"]*\"/PublicIP=\"$PUBLIC_IP\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
@@ -269,6 +278,7 @@ if [ -n "${COOP_PLAYER_MAX_NUM}" ]; then
     sed -E -i "s/CoopPlayerMaxNum=[0-9]*/CoopPlayerMaxNum=$COOP_PLAYER_MAX_NUM/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${REGION}" ]; then
+    REGION=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$REGION")
     echo "REGION=$REGION"
     sed -E -i "s/Region=\"[^\"]*\"/Region=\"$REGION\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
@@ -277,6 +287,7 @@ if [ -n "${USEAUTH}" ]; then
     sed -E -i "s/bUseAuth=[a-zA-Z]*/bUseAuth=$USEAUTH/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${BAN_LIST_URL}" ]; then
+    BAN_LIST_URL=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$BAN_LIST_URL")
     echo "BAN_LIST_URL=$BAN_LIST_URL"
     sed -E -i "s~BanListURL=\"[^\"]*\"~BanListURL=\"$BAN_LIST_URL\"~" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Fix incorrect environment variable handling

## Choices

* In `PalWorldSettings.ini`, `ServerName`, `ServerDescription`, `AdminPassword`, `ServerPassword`, `PublicIP`, `Region`, and `BanListURL` should be enclosed in double quotes.
* Fix the incorrect handling of double quotes in `start.sh`.

## Test instructions

1. Stop the Palworld server.
2. Build the container.
3. Delete `<mount_folder>/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini`.
4. Set a `SERVER_NAME` with spaces in the .env. e.g. SERVER_NAME="My Palworld Server"
5. Start the Palworld server.
6. Check the server name in the game.

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.
