### PR TITLE
FIX: start.sh not placing quotes around values in config file

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -42,19 +42,22 @@ fi
 
 if [ -n "${SERVER_NAME}" ]; then
     echo "SERVER_NAME=${SERVER_NAME}"
-    sed -E -i "s/ServerName=\"[^\"]*\"/ServerName=$SERVER_NAME/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    sed -E -i "s/ServerName=\"[^\"]*\"/ServerName=\"$SERVER_NAME\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
+
 if [ -n "${SERVER_DESCRIPTION}" ]; then
     echo "SERVER_DESCRIPTION=${SERVER_DESCRIPTION}"
-    sed -E -i "s/ServerDescription=\"[^\"]*\"/ServerDescription=$SERVER_DESCRIPTION/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    sed -E -i "s/ServerDescription=\"[^\"]*\"/ServerDescription=\"$SERVER_DESCRIPTION\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
+
 if [ -n "${SERVER_PASSWORD}" ]; then
     echo "SERVER_PASSWORD=${SERVER_PASSWORD}"
-    sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=$SERVER_PASSWORD/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"$SERVER_PASSWORD\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
+
 if [ -n "${ADMIN_PASSWORD}" ]; then
-    echo "ADMIN_PASSWORD=${ADMIN_PASSWORD}" 
-    sed -E -i "s/AdminPassword=\"[^\"]*\"/AdminPassword=$ADMIN_PASSWORD/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    echo "ADMIN_PASSWORD=${ADMIN_PASSWORD}"
+    sed -E -i "s/AdminPassword=\"[^\"]*\"/AdminPassword=\"$ADMIN_PASSWORD\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${PLAYERS}" ]; then
     echo "PLAYERS=${PLAYERS}"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

With #203, `start.sh` was changed from passing arguments to `PalServer.sh` to directly editing the config file. It appears that for values in the config file to be accepted, they must be surrounded in quotes. This PR fixes this for `ServerName`, `ServerDescription`, `ServerPassword`, and `AdminPassword`.

## Choices

#203 effectively sets `ServerName`, `ServerDescription`, `ServerPassword`, and `AdminPassword` to their defaults, no matter what the environment variables are. 

## Test instructions


Before this fix, `start.sh` produced this config:
```
; This configuration file is a sample of the default server settings.
; Changes to this file will NOT be reflected on the server.
; To change the server settings, modify Pal/Saved/Config/LinuxServer/PalWorldSettings.ini.
[/Script/Pal.PalGameWorldSettings]
OptionSettings=(Difficulty=None,DayTimeSpeedRate=1.000000,NightTimeSpeedRate=1.000000,ExpRate=1.000000,PalCaptureRate=1.000000,PalSpawnNumRate=1.000000,PalDamageRateAttack=1.000000,PalDamageRateDefense=1.000000,PlayerDamageRateAttack=1.000000,PlayerDamageRateDefense=1.000000,PlayerStomachDecreaceRate=1.000000,PlayerStaminaDecreaceRate=1.000000,PlayerAutoHPRegeneRate=1.000000,PlayerAutoHpRegeneRateInSleep=1.000000,PalStomachDecreaceRate=1.000000,PalStaminaDecreaceRate=1.000000,PalAutoHPRegeneRate=1.000000,PalAutoHpRegeneRateInSleep=1.000000,BuildObjectDamageRate=1.000000,BuildObjectDeteriorationDamageRate=1.000000,CollectionDropRate=1.000000,CollectionObjectHpRate=1.000000,CollectionObjectRespawnSpeedRate=1.000000,EnemyDropItemRate=1.000000,DeathPenalty=All,bEnablePlayerToPlayerDamage=False,bEnableFriendlyFire=False,bEnableInvaderEnemy=True,bActiveUNKO=False,bEnableAimAssistPad=True,bEnableAimAssistKeyboard=False,DropItemMaxNum=3000,DropItemMaxNum_UNKO=100,BaseCampMaxNum=128,BaseCampWorkerMaxNum=15,DropItemAliveMaxHours=1.000000,bAutoResetGuildNoOnlinePlayers=False,AutoResetGuildTimeNoOnlinePlayers=72.000000,GuildPlayerMaxNum=20,PalEggDefaultHatchingTime=72.000000,WorkSpeedRate=1.000000,bIsMultiplay=False,bIsPvP=False,bCanPickupOtherGuildDeathPenaltyDrop=False,bEnableNonLoginPenalty=True,bEnableFastTravel=True,bIsStartLocationSelectByMap=True,bExistPlayerAfterLogout=False,bEnableDefenseOtherGuildPlayer=False,CoopPlayerMaxNum=4,ServerPlayerMaxNum=32,ServerName=servername,ServerDescription=serverdescription,AdminPassword=test,ServerPassword=serverpass,PublicPort=8211,PublicIP="",RCONEnabled=true,RCONPort=25575,Region="",bUseAuth=True,BanListURL="https://api.palworldgame.com/api/banlist.txt")

```

This config effectively sets `ServerName`, `ServerDescription`, `ServerPassword`, and `AdminPassword` to the default, meaning that the server would accept any password and RCON would not accept any password. 

After this PR, 

```
; This configuration file is a sample of the default server settings.
; Changes to this file will NOT be reflected on the server.
; To change the server settings, modify Pal/Saved/Config/LinuxServer/PalWorldSettings.ini.
[/Script/Pal.PalGameWorldSettings]
OptionSettings=(Difficulty=None,DayTimeSpeedRate=1.000000,NightTimeSpeedRate=1.000000,ExpRate=1.000000,PalCaptureRate=1.000000,PalSpawnNumRate=1.000000,PalDamageRateAttack=1.000000,PalDamageRateDefense=1.000000,PlayerDamageRateAttack=1.000000,PlayerDamageRateDefense=1.000000,PlayerStomachDecreaceRate=1.000000,PlayerStaminaDecreaceRate=1.000000,PlayerAutoHPRegeneRate=1.000000,PlayerAutoHpRegeneRateInSleep=1.000000,PalStomachDecreaceRate=1.000000,PalStaminaDecreaceRate=1.000000,PalAutoHPRegeneRate=1.000000,PalAutoHpRegeneRateInSleep=1.000000,BuildObjectDamageRate=1.000000,BuildObjectDeteriorationDamageRate=1.000000,CollectionDropRate=1.000000,CollectionObjectHpRate=1.000000,CollectionObjectRespawnSpeedRate=1.000000,EnemyDropItemRate=1.000000,DeathPenalty=All,bEnablePlayerToPlayerDamage=False,bEnableFriendlyFire=False,bEnableInvaderEnemy=True,bActiveUNKO=False,bEnableAimAssistPad=True,bEnableAimAssistKeyboard=False,DropItemMaxNum=3000,DropItemMaxNum_UNKO=100,BaseCampMaxNum=128,BaseCampWorkerMaxNum=15,DropItemAliveMaxHours=1.000000,bAutoResetGuildNoOnlinePlayers=False,AutoResetGuildTimeNoOnlinePlayers=72.000000,GuildPlayerMaxNum=20,PalEggDefaultHatchingTime=72.000000,WorkSpeedRate=1.000000,bIsMultiplay=False,bIsPvP=False,bCanPickupOtherGuildDeathPenaltyDrop=False,bEnableNonLoginPenalty=True,bEnableFastTravel=True,bIsStartLocationSelectByMap=True,bExistPlayerAfterLogout=False,bEnableDefenseOtherGuildPlayer=False,CoopPlayerMaxNum=4,ServerPlayerMaxNum=32,ServerName="servername",ServerDescription="serverdescription",AdminPassword="test",ServerPassword="serverpass",PublicPort=8211,PublicIP="",RCONEnabled=true,RCONPort=25575,Region="",bUseAuth=True,BanListURL="https://api.palworldgame.com/api/banlist.txt")
```

which works as expected. 

Reverting c11bc2dbe266359f7ddae3eda2c435eca62eade2 also solves the issue of the settings seemingly being ignored. 

Fixes #214 

This is probably related to other settings-related issues that cropped up in v0.19.0


## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
