### PR TITLE
add support macOS

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,7 +2,7 @@
 
 if [ "${UPDATE_ON_BOOT}" = true ]; then
     printf "\e[0;32m*****STARTING INSTALL/UPDATE*****\e[0m\n"
-    /home/steam/steamcmd/steamcmd.sh +force_install_dir "/palworld" +login anonymous +app_update 2394010 validate +quit
+    /home/steam/steamcmd/steamcmd.sh +@sSteamCmdForcePlatformType linux +@sSteamCmdForcePlatformBitness 64 +force_install_dir "/palworld" +login anonymous +app_update 2394010 validate +quit
 fi
 
 STARTCOMMAND=("./PalServer.sh")


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Add support macOS.

## Choices

* `steamcmd` does not work properly on Docker in Apple Silicon environments, added two force tags(force platform type to linux and force platform bitness to 64) as it's just a command to download PalWorld dedicated server for a linux.

## Test instructions

1. I built my own docker image with this changes and running private server on M1 Max Mac Studio with 32GB RAM.

## Checklist before requesting a review

* [X] I have performed a self-review of my code
* [X] I've added documentation about this change to the README.
* [X] I've not introduced breaking changes.
