### PR TITLE
Fix RCON variable handling

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -293,7 +293,11 @@ if [ -n "${BAN_LIST_URL}" ]; then
 fi
 if [ -n "${RCON_ENABLED}" ]; then
     echo "RCON_ENABLED=${RCON_ENABLED}"
-    sed -i "s/RCONEnabled=[a-zA-Z]*/RCONEnabled=$RCON_ENABLED/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    if [ "${RCON_ENABLED}" = true ]; then
+        sed -i "s/RCONEnabled=[a-zA-Z]*/RCONEnabled=True/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    else
+        sed -i "s/RCONEnabled=[a-zA-Z]*/RCONEnabled=False/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+    fi
 fi
 if [ -n "${RCON_PORT}" ]; then
     echo "RCON_PORT=${RCON_PORT}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -293,7 +293,7 @@ if [ -n "${BAN_LIST_URL}" ]; then
 fi
 if [ -n "${RCON_ENABLED}" ]; then
     echo "RCON_ENABLED=${RCON_ENABLED}"
-    if [ "${RCON_ENABLED}" = true ]; then
+    if [ "${RCON_ENABLED,,}" = true ]; then
         sed -i "s/RCONEnabled=[a-zA-Z]*/RCONEnabled=True/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
     else
         sed -i "s/RCONEnabled=[a-zA-Z]*/RCONEnabled=False/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

Fix RCON variable handling

## Choices

RCON setting in <code>PalWorldSettings.ini</code> 
not work:
<code>RCONEnabled=true</code>
correct: 
<code>RCONEnabled=True</code>

## Test instructions
docker run :
<pre>docker run -d \
    --name palworld-server \
    -p 8211:8211/udp \
    -p 27015:27015/udp \
    -v /data:/palworld/ \
    -e PUID=1000 \
    -e PGID=1000 \
    -e PORT=8211 \
    -e PLAYERS=16 \
    -e MULTITHREADING=true \
    -e RCON_ENABLED=true \
    -e RCON_PORT=25575 \
    -e TZ=UTC \
    -e ADMIN_PASSWORD=test \
    -e SERVER_NAME=Dog \
    -e SERVER_DESCRIPTION=20240131 \
    --restart unless-stopped \
    --stop-timeout 30 \
    --pull=always \
    thijsvanloef/palworld-server-docker:latest</pre>

verify:

run container:  <code>docker exec -it palworld-server rcon-cli info</code>

<pre>bb@bb-M1090:~/config$ docker  exec -it palworld-server rcon-cli info
Welcome to Pal Server[v0.1.3.0] Dog </pre>


## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
