### PR TITLE
Use storageClassName for pvc

### DIFF
--- a/charts/palworld/templates/pvcs.yaml
+++ b/charts/palworld/templates/pvcs.yaml
@@ -27,5 +27,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.server.storage.size }}
+{{- if .Values.server.storage.storageClassName }}
+{{- if (eq "-" .Values.server.storage.storageClassName) }}
+  storageClassName: ""
+{{- else }}
   storageClassName: {{ .Values.server.storage.storageClassName }}
-{{ end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
In this pull request, I aim to address an issue related to the storageClassName in the resources section.

follow the best pratice.

## Test instructions

1. Verify that the storageClassName is correctly set based on the provided size.
2. Ensure that when storageClassName is "-", it is properly handled and results in an empty storageClassName.

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.
