### PR TITLE
[Kubernetes] backup before a container is terminated

### DIFF
--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -40,6 +40,18 @@ spec:
         - name: server
           image: "{{ .Values.server.image.name }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.server.image.imagePullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c"]
+                args:
+                  - |
+                    cont=$(kubectl -n {{ .Values.namespace }} get pods -o=jsonpath='{.items[?(@.metadata.labels.app\.kubernetes\.io/name=="{{ .Release.Name }}-server")].metadata.name}')
+                    function exec_rcon_cmd() {
+                      kubectl exec -n {{ .Values.namespace }} -i pod/$cont rcon-cli "$1"
+                    }
+                    exec_rcon_cmd save
+                    exec_rcon_cmd backup
           resources:
             {{- with .Values.server.resources }}
               {{- toYaml . | nindent 12 }}

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -47,7 +47,7 @@ spec:
                 args:
                   - |
                     rcon-cli save
-                    rcon-cli backup
+                    backup
           resources:
             {{- with .Values.server.resources }}
               {{- toYaml . | nindent 12 }}

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -46,12 +46,8 @@ spec:
                 command: ["/bin/sh", "-c"]
                 args:
                   - |
-                    cont=$(kubectl -n {{ .Values.namespace }} get pods -o=jsonpath='{.items[?(@.metadata.labels.app\.kubernetes\.io/name=="{{ .Release.Name }}-server")].metadata.name}')
-                    function exec_rcon_cmd() {
-                      kubectl exec -n {{ .Values.namespace }} -i pod/$cont rcon-cli "$1"
-                    }
-                    exec_rcon_cmd save
-                    exec_rcon_cmd backup
+                    rcon-cli save
+                    rcon-cli backup
           resources:
             {{- with .Values.server.resources }}
               {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Incorporate backup functionality before the termination of a container due to API requests or management events such as liveness/startup probe failure, preemption, resource contention, and others.

## Choices

* Add backup before a container is terminated.
* Addressing https://github.com/thijsvanloef/palworld-server-docker/issues/243#issue-2110148331
* Refer to https://github.com/thijsvanloef/palworld-server-docker/pull/206#issue-2105868641

## Test instructions

1. I haven't tested it yet. I'll conduct the test in a few days.

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
