### PR TITLE
Added waiting for backups to complete before stopping

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -8,6 +8,7 @@ DATE=$(date +"%Y-%m-%d_%H-%M-%S")
 FILE_PATH="/palworld/backups/palworld-save-${DATE}.tar.gz"
 cd /palworld/Pal/ || exit
 
+echo "Creating backup"
 tar -zcf "$FILE_PATH" "Saved/"
 
 if [ "$(id -u)" -eq 0 ]; then

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -28,3 +28,9 @@ su steam -c ./start.sh &
 # Process ID of su
 killpid="$!"
 wait $killpid
+
+echo "Waiting for backup to finish"
+backup_pids=($(pgrep backup))
+for pid in "${backup_pids[@]}"; do
+    tail --pid=$pid -f 2>/dev/null
+done


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Currently the container can stop while a backup is running

## Choices

* Using pgrep instead of pidof as pidof only works for child processes
* Using a loop and array in the event multiple backups are running 

## Test instructions

1. Create a large file to force backup to take a while `fallocate -l 10G palworld/Pal/Saved/deleteme`
2. Start the container
3. Stop the server and while creating a backup `docker exec -it palworld-server rcon-cli "shutdown 1" && docker exec -it palworld-server backup`

> [!TIP]
> If the container is being killed before backup is completed then try increasing `stop_grace_period`.
> If the backup is done too quickly to see that it's waiting then try increasing the size large file.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
