### PR TITLE
Add quotes to rcon.yaml password

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -320,7 +320,7 @@ fi
 cat >/home/steam/server/rcon.yaml  <<EOL
 default:
   address: "127.0.0.1:${RCON_PORT}"
-  password: ${ADMIN_PASSWORD}
+  password: '${ADMIN_PASSWORD}'
 EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -320,7 +320,7 @@ fi
 cat >/home/steam/server/rcon.yaml  <<EOL
 default:
   address: "127.0.0.1:${RCON_PORT}"
-  password: '${ADMIN_PASSWORD}'
+  password: "${ADMIN_PASSWORD}"
 EOL
 
 printf "\e[0;32m*****STARTING SERVER*****\e[0m\n"


### PR DESCRIPTION
Quotes allow for special characters to be used in the password field for the rcon config yaml.

## Context <!-- markdownlint-disable MD041 -->

* Allow or the use of special characters in rcon and admin passwords
## Choices

* This is what yaml allows 
## Test instructions

Tested with and without special characters.
1. Set env vars
2. Run EOL text insertion
3.  run `rcon-cli` to check errors
## Checklist before requesting a review

* [X] I have performed a self-review of my code
* [X] I've added documentation about this change to the README. (Documentation shouldn't be required as there is no documentation stating a limitation.)
* [X] I've not introduced breaking changes.
