### PR TITLE
Corrected Generat to Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ BACKUP_CRON_EXPRESSION is a cron expression, in a Cron-Expression you define an 
 > This image uses Supercronic for crons
 > see [supercronic](https://github.com/aptible/supercronic#crontab-format)
 > or
-> [Crontab Generat](https://crontab-generator.org).
+> [Crontab Generator](https://crontab-generator.org).
 
 Set BACKUP_CRON_EXPRESSION to change the default schedule.
 Example Usage: If BACKUP_CRON_EXPRESSION to `0 2 * * *`, the backup script will run every day at 2:00 AM.
@@ -286,7 +286,7 @@ AUTO_UPDATE_CRON_EXPRESSION is a cron expression, in a Cron-Expression you defin
 > This image uses Supercronic for crons
 > see [supercronic](https://github.com/aptible/supercronic#crontab-format)
 > or
-> [Crontab Generat](https://crontab-generator.org).
+> [Crontab Generator](https://crontab-generator.org).
 
 Set AUTO_UPDATE_CRON_EXPRESSION to change the default schedule.
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* @Technetium1 for pointing out the misspelling

## Choices

* Corrected readme

## Test instructions

1. Verify it is indeed spelled correctly

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.