### PR TITLE
Pause without players

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL maintainer="thijs@loef.dev" \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     procps=2:3.3.17-5 \
     wget=1.21-1+deb11u1 \
+    tcpdump=4.99.0-2+deb11u1 \
     xdg-user-dirs=0.17-2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,8 @@ COPY ./scripts/* /home/steam/server/
 RUN chmod +x /home/steam/server/*.sh && \
     mv /home/steam/server/backup.sh /usr/local/bin/backup && \
     mv /home/steam/server/update.sh /usr/local/bin/update && \
-    mv /home/steam/server/restore.sh /usr/local/bin/restore
+    mv /home/steam/server/restore.sh /usr/local/bin/restore && \
+    mv /home/steam/server/pause.sh /usr/local/bin/pause
 
 WORKDIR /home/steam/server
 

--- a/scripts/pause.sh
+++ b/scripts/pause.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+PID=$(pidof PalServer-Linux-Test)
+PID_STATE=$(grep State /proc/$PID/status | cut -d '(' -f2 | cut -d ')' -f1)
+LOCKFILE=/tmp/port_listener.lock
+
+if [ -f "$LOCKFILE" ]; then
+    exit 0
+fi
+
+if [ "${RCON_ENABLED}" = true ]; then
+    PLAYERLIST=$(rcon-cli -c /home/steam/server/rcon.yaml "ShowPlayers")
+
+    if [ $(echo -n "$PLAYERLIST" | wc -l) -gt 0 ]; then
+        exit 0
+    fi
+    rcon-cli -c /home/steam/server/rcon.yaml save  
+fi
+
+monitor_traffic() {
+    touch "$LOCKFILE"
+    cleanup() {
+        rm -f "$LOCKFILE"
+    }
+    while true; do
+        packet_capture=$(tcpdump -n -c 1 -i any port $1 2>/dev/null)
+        if [ -n "$packet_capture" ]; then
+            echo "Connection attempt detected resuming the server" >> /proc/1/fd/1
+            kill -CONT "$2"
+            break
+        fi
+        sleep 1
+    done
+    trap 'cleanup' EXIT
+}
+
+if [ "$PID_STATE" != "stopped" ]; then
+    kill -STOP $PID
+    echo "Server paused" >> /proc/1/fd/1
+    monitor_traffic $PORT $PID &
+fi

--- a/scripts/pause.sh
+++ b/scripts/pause.sh
@@ -19,8 +19,10 @@ fi
 monitor_traffic() {
     touch "$LOCKFILE"
     cleanup() {
+        # shellcheck disable=SC2317
         rm -f "$LOCKFILE"
     }
+    trap 'cleanup' EXIT
     while true; do
         packet_capture=$(tcpdump -n -c 1 -i any port "$1" 2>/dev/null)
         if [ -n "$packet_capture" ]; then
@@ -30,7 +32,7 @@ monitor_traffic() {
         fi
         sleep 1
     done
-    trap 'cleanup' EXIT
+    exit 0
 }
 
 if [ "$PID_STATE" != "stopped" ]; then

--- a/scripts/pause.sh
+++ b/scripts/pause.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PID=$(pidof PalServer-Linux-Test)
-PID_STATE=$(grep State /proc/$PID/status | cut -d '(' -f2 | cut -d ')' -f1)
+PID_STATE=$(grep State "/proc/$PID/status" | cut -d '(' -f2 | cut -d ')' -f1)
 LOCKFILE=/tmp/port_listener.lock
 
 if [ -f "$LOCKFILE" ]; then
@@ -10,7 +10,7 @@ fi
 if [ "${RCON_ENABLED}" = true ]; then
     PLAYERLIST=$(rcon-cli -c /home/steam/server/rcon.yaml "ShowPlayers")
 
-    if [ $(echo -n "$PLAYERLIST" | wc -l) -gt 0 ]; then
+    if [ "$(echo -n "$PLAYERLIST" | wc -l)" -gt 0 ]; then
         exit 0
     fi
     rcon-cli -c /home/steam/server/rcon.yaml save  
@@ -22,7 +22,7 @@ monitor_traffic() {
         rm -f "$LOCKFILE"
     }
     while true; do
-        packet_capture=$(tcpdump -n -c 1 -i any port $1 2>/dev/null)
+        packet_capture=$(tcpdump -n -c 1 -i any port "$1" 2>/dev/null)
         if [ -n "$packet_capture" ]; then
             echo "Connection attempt detected resuming the server" >> /proc/1/fd/1
             kill -CONT "$2"
@@ -34,7 +34,7 @@ monitor_traffic() {
 }
 
 if [ "$PID_STATE" != "stopped" ]; then
-    kill -STOP $PID
+    kill -STOP "$PID"
     echo "Server paused" >> /proc/1/fd/1
-    monitor_traffic $PORT $PID &
+    monitor_traffic "$PORT" "$PID" &
 fi


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Adds the ability to pause the server
* Addressing #32 

## Choices

* Added an additional Script that will send a SIGSTOP to the server. After the process is suspended, it will monitor the server port for any connection attempts.
* If a player connects to the port it will resume the process and the player will be able to spawn without a timeout.

**Feedback is appreciated, if you see something that can be improved!**

### Todo

* Add Cronjob
* RCON handling if the server is suspended
* Test how suspending the process reflects on the Ingame time
* Check if port is set

## Test instructions

### Manually
1. Start the server with the default docker compose file
2. run `docker exec palworld-server pause`
3. check the server log for a message, that the server has been paused
4. run `echo>/dev/udp/127.0.0.1/8211` or start the game and login
5. check that the server has continued

### Cron
1. todo

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.
