### PR TITLE
Fix: with no `SERVER_PASSWORD` can still apply setting

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -122,7 +122,7 @@ if [ -n "${SERVER_PASSWORD}" ]; then
     SERVER_PASSWORD=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$SERVER_PASSWORD")
     echo "SERVER_PASSWORD=${SERVER_PASSWORD}"
     sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"$SERVER_PASSWORD\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
-elif [ -v SERVER_PASSWORD ]; then
+elif [ -v "${SERVER_PASSWORD}" ]; then
     echo "No SERVER_PASSWORD"
     sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -122,8 +122,8 @@ if [ -n "${SERVER_PASSWORD}" ]; then
     SERVER_PASSWORD=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$SERVER_PASSWORD")
     echo "SERVER_PASSWORD=${SERVER_PASSWORD}"
     sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"$SERVER_PASSWORD\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
-elif [ -v "${SERVER_PASSWORD}" ]; then
-    echo "No SERVER_PASSWORD"
+elif [ -z "${SERVER_PASSWORD}" ]; then
+    printf "\033[0;31mNO SERVER_PASSWORD SET\033[0m\n"
     sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${ADMIN_PASSWORD}" ]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -122,7 +122,7 @@ if [ -n "${SERVER_PASSWORD}" ]; then
     SERVER_PASSWORD=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$SERVER_PASSWORD")
     echo "SERVER_PASSWORD=${SERVER_PASSWORD}"
     sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"$SERVER_PASSWORD\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
-else
+elif [ -v SERVER_PASSWORD ]; then
     echo "No SERVER_PASSWORD"
     sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -122,6 +122,9 @@ if [ -n "${SERVER_PASSWORD}" ]; then
     SERVER_PASSWORD=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$SERVER_PASSWORD")
     echo "SERVER_PASSWORD=${SERVER_PASSWORD}"
     sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"$SERVER_PASSWORD\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+else
+    echo "No SERVER_PASSWORD"
+    sed -E -i "s/ServerPassword=\"[^\"]*\"/ServerPassword=\"\"/" /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 fi
 if [ -n "${ADMIN_PASSWORD}" ]; then
     ADMIN_PASSWORD=$(sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/" <<< "$ADMIN_PASSWORD")


### PR DESCRIPTION
## Choices
*  Allow setting `ServerPassword` to an empty string through env `SERVER_PASSWORD`
* Resolve the issue of applying settings without manually modifying PalWorldSettings.ini when there is no server password.
* Addressing a similar issue as described in https://github.com/thijsvanloef/palworld-server-docker/issues/275#issue-2115930445.

## Test instructions

1. Comment out the SERVER_PASSWORD or set it to an empty string.
2. Open the game and check if the `ServerPassword` in PalWorldSettings.ini is set to an empty string.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
