### PR TITLE
[FIX] fixed tips for docker compose & translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ The `RCON_ENABLED` environment variable must be set to `true` to use this comman
 ## Manually restore from a backup
 
 Locate the backup you want to restore in `/palworld/backups/` and decompress it.
+Need to stop the server before task.
+
+```bash
+docker compose down
+```
 
 Delete the old saved data folder located at `palworld/Pal/Saved/SaveGames/0/<old_hash_value>`.
 
@@ -277,7 +282,7 @@ DedicatedServerName=<new_hash_value>  # Replace it with your folder name.
 Restart the game. (If you are using Docker Compose)
 
 ```bash
-docker compose down && docker compose up -d
+docker compose up -d
 ```
 
 ## Configuring Automatic Backups with Cron

--- a/docs/kr/README.md
+++ b/docs/kr/README.md
@@ -4,10 +4,11 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/thijsvanloef/palworld-server-docker)](https://hub.docker.com/r/thijsvanloef/palworld-server-docker)
 [![Docker Stars](https://img.shields.io/docker/stars/thijsvanloef/palworld-server-docker)](https://hub.docker.com/r/thijsvanloef/palworld-server-docker)
 [![Image Size](https://img.shields.io/docker/image-size/thijsvanloef/palworld-server-docker/latest)](https://hub.docker.com/r/thijsvanloef/palworld-server-docker/tags)
+[![Static Badge](https://img.shields.io/badge/readme-0.19.1-blue?link=https%3A%2F%2Fgithub.com%2Fthijsvanloef%2Fpalworld-server-docker%2Fblob%2Fmain%2FREADME.md)](https://github.com/thijsvanloef/palworld-server-docker?tab=readme-ov-file#palworld-dedicated-server-docker)
 [![Discord](https://img.shields.io/discord/1200397673329594459?logo=discord&label=Discord&link=https%3A%2F%2Fdiscord.gg%2FUxBxStPAAE)](https://discord.com/invite/UxBxStPAAE)
-[![Static Badge](https://img.shields.io/badge/README-0.16.0-blue?link=https%3A%2F%2Fgithub.com%2Fthijsvanloef%2Fpalworld-server-docker%2Fblob%2Fmain%2FREADME.md)](https://github.com/thijsvanloef/palworld-server-docker/blob/main/docs/kr/README.md?tab=readme-ov-file#palworld-dedicated-server-docker)
 
-[Docker Hub에서 보기](https://hub.docker.com/r/thijsvanloef/palworld-server-docker)
+[![Docker Hub](https://img.shields.io/badge/Docker_Hub-palworld-blue?logo=docker)](https://hub.docker.com/r/thijsvanloef/palworld-server-docker)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/palworld)](https://artifacthub.io/packages/search?repo=palworld)
 
 [Discord에서 커뮤니티와 채팅하세요](https://discord.gg/UxBxStPAAE)
 
@@ -31,7 +32,7 @@
 | ------ | ------- | ----------------------------------- |
 | CPU    | 4 cores | 4+ cores                            |
 | RAM    | 16GB    | 안정적인 운영을 위해 32GB 이상 권장 |
-| 저장소 | 4GB     | 12GB                                |
+| 저장소 | 8GB     | 20GB                                |
 
 ## 사용하기
 
@@ -60,10 +61,29 @@ services:
       - MULTITHREADING=true
       - RCON_ENABLED=true
       - RCON_PORT=25575
-      - TZ=UTC
+      - TZ=KST
       - ADMIN_PASSWORD="adminPasswordHere"
       - COMMUNITY=false # 커뮤니티 서버 탐색기에 서버가 표시 되는 것을 허용합니다 (USE WITH SERVER_PASSWORD 와 함께 사용하는 것을 권장합니다)
       - SERVER_NAME="World of Pals"
+    volumes:
+      - ./palworld:/palworld/
+```
+
+또 다른 방법으로, .env.example 파일을 .env라는 새 파일로 복사할 수 있습니다.
+필요에 따라 수정하고, 올바른 값을 확인하려면 환경 변수 섹션을 확인하세요. 아래와 같이 docker-compose.yml을 수정하세요:
+
+```yml
+services:
+  palworld:
+    image: thijsvanloef/palworld-server-docker:latest
+    restart: unless-stopped
+    container_name: palworld-server
+    stop_grace_period: 30s # 컨테이너가 정상적으로 중지될 때까지 기다리는 시간을 설정합니다.
+    ports:
+      - 8211:8211/udp
+      - 27015:27015/udp
+    env_file:
+      - .env
     volumes:
       - ./palworld:/palworld/
 ```
@@ -85,20 +105,31 @@ docker run -d \
     -e MULTITHREADING=true \
     -e RCON_ENABLED=true \
     -e RCON_PORT=25575 \
-    -e TZ=UTC \
-    -e ADMIN_PASSWORD="adminPasswordHere" \
-    -e SERVER_PASSWORD="worldofpals" \
+    -e TZ=KST \
+    -e ADMIN_PASSWORD=adminPasswordHere \
+    -e SERVER_PASSWORD=worldofpals \
     -e COMMUNITY=false \
-    -e SERVER_NAME="World of Pals" \
-    -e SERVER_DESCRIPTION="Awesome World of Pal" \
+    -e SERVER_NAME=World of Pals \
+    -e SERVER_DESCRIPTION=palworld-server-docker by Thijs van Loef \
     --restart unless-stopped \
+    --stop-timeout 30 \
     thijsvanloef/palworld-server-docker:latest
-
 ```
 
-> [!TIP]
-> 사용자 지정 중지 유예 기간을 설정하여 컨테이너를 중지하려면 다음을 실행하세요:
-> `docker stop --name palworld-server --time 30`
+또 다른 방법으로, .env.example 파일을 .env라는 새 파일로 복사할 수 있습니다.
+필요에 따라 수정하고, 올바른 값을 확인하려면 환경 변수 섹션을 확인하세요. docker run 명령어를 다음과 같이 변경하세요:
+
+```bash
+docker run -d \
+    --name palworld-server \
+    -p 8211:8211/udp \
+    -p 27015:27015/udp \
+    -v ./<palworld-folder>:/palworld/ \
+    --env-file .env \
+    --restart unless-stopped \
+    --stop-timeout 30 \
+    thijsvanloef/palworld-server-docker:latest
+```
 
 ### Kubernetes
 
@@ -122,7 +153,7 @@ docker run -d \
 
 | 변수명             | 정보                                                                                                                                                     | 기본값 | 허용되는 값                                                                                            |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------ |
-| TZ                 | 서버 백업에 사용되는 타임스템프 시간대                                                                                                                   | UTC    | [TZ Identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#Time_Zone_abbreviations) |
+| TZ                 | 서버 백업에 사용되는 타임스템프 시간대                                                                                                                   | KST    | [TZ Identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#Time_Zone_abbreviations) |
 | PLAYERS\*          | 서버에 참여할 수 있는 최대 플레이어 수                                                                                                                   | 16     | 1-32                                                                                                   |
 | PORT\*             | 서버에 사용되는 포트(UDP)                                                                                                                                | 8211   | 1024-65535                                                                                             |
 | PUID\*             | 서버를 실행할 사용자의 아이디입니다.                                                                                                                     | 1000   | !0                                                                                                     |
@@ -140,16 +171,11 @@ docker run -d \
 | RCON_PORT          | RCON접속 포트                                                                                                                                            | 25575  | 1024-65535                                                                                             |
 | QUERY_PORT         | Steam 서버와 통신하는 데 사용되는 쿼리 포트                                                                                                              | 27015  | 1024-65535                                                                                             |
 
-\* 설정하는 것을 적극 권장합니다.
+*설정하는 것을 적극 권장합니다.
 
-\*\* 이 옵션을 활성화하여 실행할 때 주의해야 할 사항을 확인하세요.
+** 이 옵션을 활성화하여 실행할 때 주의해야 할 사항을 확인하세요.
 
-\*\*\* docker stop이 서버를 저장하고 정상적으로 종료하는 데 필요합니다.
-
-> [!IMPORTANT]
-> 환경 변수에 사용되는 부울(true/false) 값은 shell 스크립트에서 사용되므로 대소문자를 구분합니다.
->
-> 옵션이 적용되려면 정확히 `true` 또는 `false`를 사용하여 설정해야 합니다.
+*** docker stop이 서버를 저장하고 정상적으로 종료하는 데 필요합니다.
 
 ### 사용되는 포트
 
@@ -164,7 +190,13 @@ docker run -d \
 RCON은 palworld-server-docker 이미지에 기본적으로 활성화되어 있습니다. RCON CLI는 아주 쉽게 열 수 있습니다:
 
 ```bash
-docker exec -it palworld-server rcon-cli
+docker exec -it palworld-server rcon-cli "<command> <value>"
+```
+
+예를 들어, 다음 명령어를 사용하여 서버의 모든 사람에게 메시지를 방송할 수 있습니다:
+
+```bash
+docker exec -it palworld-server rcon-cli "Broadcast Hello everyone"
 ```
 
 위 명령어를 사용 하면 RCON을 사용하여 Palworld 서버 명령어를 작성할 수 있는 CLI가 열립니다.
@@ -212,6 +244,94 @@ docker exec -it palworld-server restore
 > 도커 `restart` 정책이 `always` 또는 `unless-stopped`로 설정 되어있지 않다면 복원 이후 컨테이너가 종료되므로 수동으로 재시작 해야 합니다.
 >
 > [사용하기](#사용하기)에서 제공된 Docker 실행 명령어와 Docker Compose 파일 예시는 이미 필요한 정책을 적용하고 있습니다.
+
+## 수동으로 백업에서 복원하기
+
+/palworld/backups/에서 복원하고자 하는 백업을 찾아서 압축을 풉니다.
+작업을 시작하기 전에 서버를 중지해야 합니다.
+
+```bash
+docker compose down
+```
+
+`palworld/Pal/Saved/SaveGames/0/<old_hash_value>`에 위치한 기존 저장 데이터 폴더를 삭제합니다.
+
+새롭게 압축 해제된 저장 데이터 폴더 `Saved/SaveGames/0/<new_hash_value>`의 내용을 `palworld/Pal/Saved/SaveGames/0/<new_hash_value>`로 복사합니다.
+
+`palworld/Pal/Saved/Config/LinuxServer/GameUserSettings.ini`` 안의 DedicatedServerName을 새 폴더 이름으로 교체합니다.
+
+```ini
+DedicatedServerName=<new_hash_value>  # 폴더 이름으로 교체하세요.
+```
+
+게임을 재시작합니다. (Docker Compose를 사용하는 경우)
+
+```bash
+docker compose up -d
+```
+
+## Cron을 이용한 자동 백업 설정
+
+서버는 TZ로 설정된 시간대에 따라 매일 자정에 자동으로 백업됩니다.
+
+BACKUP_ENABLED를 설정하여 자동 백업을 활성화하거나 비활성화합니다 (기본값은 활성화됨).
+
+BACKUP_CRON_EXPRESSION은 cron 표현식으로, Cron 표현식에서는 작업을 실행할 간격을 정의합니다.
+
+> [!팁]
+> 이 이미지는 cron 작업을 위해 Supercronic을 사용합니다.
+> [supercronic](https://github.com/aptible/supercronic#crontab-format) 또는
+> [Crontab Generator](https://crontab-generator.org)를 참조하세요.
+
+BACKUP_CRON_EXPRESSION을 설정하여 기본 스케줄을 변경합니다.
+예시: `0 2 * * *`로 BACKUP_CRON_EXPRESSION을 설정하면, 백업 스크립트는 매일 새벽 2시에 실행됩니다.
+
+## Cron을 이용한 자동 업데이트 설정
+
+이 서버에서 자동 업데이트를 사용하려면 다음 환경 변수들을 `true`로 **설정해야 합니다**:
+
+* RCON_ENABLED
+* UPDATE_ON_BOOT
+
+> [!중요]
+>
+> docker 재시작 정책이 `always` 또는 `unless-stopped`로 설정되어 있지 않다면, 서버는 종료되고
+> 수동으로 다시 시작해야 합니다.
+>
+> [How to Use](#how-to-use)에서 이미 필요한 정책을 사용하는 예시 docker run 명령어와 docker compose 파일이 있습니다.
+
+AUTO_UPDATE_ENABLED를 설정하여 자동 업데이트를 활성화하거나 비활성화합니다 (기본값은 비활성화됨).
+
+AUTO_UPDATE_CRON_EXPRESSION은 cron 표현식으로, Cron 표현식에서는 작업을 실행할 간격을 정의합니다.
+
+> [!팁]
+> 이 이미지는 cron 작업을 위해 Supercronic을 사용합니다.
+> [supercronic](https://github.com/aptible/supercronic#crontab-format) 또는
+> [Crontab Generator](https://crontab-generator.org)를 참조하세요.
+
+AUTO_UPDATE_CRON_EXPRESSION을 설정하여 기본 스케줄을 변경합니다.
+
+## Cron을 이용한 자동 재부팅 설정
+
+이 서버에서 자동 재부팅을 사용하려면 RCON_ENABLED를 활성화해야 합니다.
+
+> [!중요]
+>
+> docker 재시작 정책이 always 또는 unless-stopped로 설정되어 있지 않다면, 서버는 종료되고
+> 수동으로 다시 시작해야 합니다.
+>
+> [How to Use](#how-to-use)에서 이미 필요한 정책을 사용하는 예시 docker run 명령어와 docker compose 파일이 있습니다.
+
+AUTO_REBOOT_ENABLED를 설정하여 자동 재부팅을 활성화하거나 비활성화합니다 (기본값은 비활성화됨).
+
+AUTO_REBOOT_CRON_EXPRESSION은 cron 표현식으로, Cron 표현식에서는 작업을 실행할 간격을 정의합니다.
+
+> [!팁]
+> 이 이미지는 cron 작업을 위해 Supercronic을 사용합니다.
+> [supercronic](https://github.com/aptible/supercronic#crontab-format) 또는
+> [Crontab Generator](https://crontab-generator.org)를 참조하세요.
+
+AUTO_REBOOT_CRON_EXPRESSION을 설정하여 기본 스케줄을 변경하세요. 기본 설정은 TZ로 설정된 시간대에 따라 매일 자정에 재부팅됩니다.
 
 ## 서버 설정 편집
 

--- a/docs/kr/README.md
+++ b/docs/kr/README.md
@@ -69,8 +69,8 @@ services:
       - ./palworld:/palworld/
 ```
 
-또 다른 방법으로, .env.example 파일을 .env라는 새 파일로 복사할 수 있습니다.
-필요에 따라 수정하고, 올바른 값을 확인하려면 환경 변수 섹션을 확인하세요. 아래와 같이 docker-compose.yml을 수정하세요:
+또 다른 방법으로, **.env.example** 파일을 **.env**라는 새 파일로 복사할 수 있습니다.
+필요에 따라 수정하고, 올바른 값을 확인하려면 환경 변수 섹션을 확인하세요. 아래와 같이 **docker-compose.yml**을 수정하세요:
 
 ```yml
 services:
@@ -247,7 +247,7 @@ docker exec -it palworld-server restore
 
 ## 수동으로 백업에서 복원하기
 
-/palworld/backups/에서 복원하고자 하는 백업을 찾아서 압축을 풉니다.
+`/palworld/backups/`에서 복원하고자 하는 백업을 찾아서 압축을 풉니다.
 작업을 시작하기 전에 서버를 중지해야 합니다.
 
 ```bash
@@ -258,7 +258,7 @@ docker compose down
 
 새롭게 압축 해제된 저장 데이터 폴더 `Saved/SaveGames/0/<new_hash_value>`의 내용을 `palworld/Pal/Saved/SaveGames/0/<new_hash_value>`로 복사합니다.
 
-`palworld/Pal/Saved/Config/LinuxServer/GameUserSettings.ini`` 안의 DedicatedServerName을 새 폴더 이름으로 교체합니다.
+`palworld/Pal/Saved/Config/LinuxServer/GameUserSettings.ini` 안의 DedicatedServerName을 새 폴더 이름으로 교체합니다.
 
 ```ini
 DedicatedServerName=<new_hash_value>  # 폴더 이름으로 교체하세요.
@@ -278,7 +278,7 @@ BACKUP_ENABLED를 설정하여 자동 백업을 활성화하거나 비활성화�
 
 BACKUP_CRON_EXPRESSION은 cron 표현식으로, Cron 표현식에서는 작업을 실행할 간격을 정의합니다.
 
-> [!팁]
+> [!TIP]
 > 이 이미지는 cron 작업을 위해 Supercronic을 사용합니다.
 > [supercronic](https://github.com/aptible/supercronic#crontab-format) 또는
 > [Crontab Generator](https://crontab-generator.org)를 참조하세요.
@@ -290,21 +290,21 @@ BACKUP_CRON_EXPRESSION을 설정하여 기본 스케줄을 변경합니다.
 
 이 서버에서 자동 업데이트를 사용하려면 다음 환경 변수들을 `true`로 **설정해야 합니다**:
 
-* RCON_ENABLED
-* UPDATE_ON_BOOT
+- RCON_ENABLED
+- UPDATE_ON_BOOT
 
-> [!중요]
+> [!IMPORTANT]
 >
 > docker 재시작 정책이 `always` 또는 `unless-stopped`로 설정되어 있지 않다면, 서버는 종료되고
 > 수동으로 다시 시작해야 합니다.
 >
-> [How to Use](#how-to-use)에서 이미 필요한 정책을 사용하는 예시 docker run 명령어와 docker compose 파일이 있습니다.
+> [How to Use](#사용하기)에서 이미 필요한 정책을 사용하는 예시 docker run 명령어와 docker compose 파일이 있습니다.
 
 AUTO_UPDATE_ENABLED를 설정하여 자동 업데이트를 활성화하거나 비활성화합니다 (기본값은 비활성화됨).
 
 AUTO_UPDATE_CRON_EXPRESSION은 cron 표현식으로, Cron 표현식에서는 작업을 실행할 간격을 정의합니다.
 
-> [!팁]
+> [!TIP]
 > 이 이미지는 cron 작업을 위해 Supercronic을 사용합니다.
 > [supercronic](https://github.com/aptible/supercronic#crontab-format) 또는
 > [Crontab Generator](https://crontab-generator.org)를 참조하세요.
@@ -315,18 +315,18 @@ AUTO_UPDATE_CRON_EXPRESSION을 설정하여 기본 스케줄을 변경합니다.
 
 이 서버에서 자동 재부팅을 사용하려면 RCON_ENABLED를 활성화해야 합니다.
 
-> [!중요]
+> [!IMPORTANT]
 >
 > docker 재시작 정책이 always 또는 unless-stopped로 설정되어 있지 않다면, 서버는 종료되고
 > 수동으로 다시 시작해야 합니다.
 >
-> [How to Use](#how-to-use)에서 이미 필요한 정책을 사용하는 예시 docker run 명령어와 docker compose 파일이 있습니다.
+> [How to Use](#사용하기)에서 이미 필요한 정책을 사용하는 예시 docker run 명령어와 docker compose 파일이 있습니다.
 
 AUTO_REBOOT_ENABLED를 설정하여 자동 재부팅을 활성화하거나 비활성화합니다 (기본값은 비활성화됨).
 
 AUTO_REBOOT_CRON_EXPRESSION은 cron 표현식으로, Cron 표현식에서는 작업을 실행할 간격을 정의합니다.
 
-> [!팁]
+> [!TIP]
 > 이 이미지는 cron 작업을 위해 Supercronic을 사용합니다.
 > [supercronic](https://github.com/aptible/supercronic#crontab-format) 또는
 > [Crontab Generator](https://crontab-generator.org)를 참조하세요.


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Adjust the order of docker compose commands when backing up data with docker compose.
  * If follow the previous commands leads to initialization issues on Ubuntu 22.04 LTS version (AWS EC2).
* Added missing Korean README translation

## Choices

* need to stop first before changing something.

## Test instructions

## Checklist before requesting a review

* [v] I have performed a self-review of my code
* [v ] I've added documentation about this change to the README.
* [v] I've not introduced breaking changes.
