### PR TITLE
Update README.md to reference the new DISCORD_WEBHOOK_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,19 +450,19 @@ For a more detailed list of explanations of server settings go to: [shockbyte](h
 
 1. Generate a webhook url for your discord server in your discord's server settings.
 
-2. Set the environment variable with the unique token at the end of the discord webhook url example: discord.com/api/webhooks/<webhook_id>
+2. Set the environment variable with the unique token at the end of the discord webhook url example: https://discord.com/api/webhooks/1234567890/abcde
 
 send discord messages with docker run:
 
 ```sh
--e DISCORD_WEBHOOK="xxxx/xxxxx" \
+-e DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/1234567890/abcde" \
 -e DISCORD_PRE_UPDATE_BOOT_MESSAGE="Server is updating..." \
 ```
 
 send discord messages with docker compose:
 
 ```yaml
-- DISCORD_WEBHOOK=xxxx/xxxxx
+- DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/1234567890/abcde
 - DISCORD_PRE_UPDATE_BOOT_MESSAGE=Server is updating...
 ```
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ For a more detailed list of explanations of server settings go to: [shockbyte](h
 
 1. Generate a webhook url for your discord server in your discord's server settings.
 
-2. Set the environment variable with the unique token at the end of the discord webhook url example: https://discord.com/api/webhooks/1234567890/abcde
+2. Set the environment variable with the unique token at the end of the discord webhook url example: `https://discord.com/api/webhooks/1234567890/abcde`
 
 send discord messages with docker run:
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* The README is out of date, and references an old ENV variable

## Choices

* Updated the README

## Test instructions

1. Follow the README to successfully use the Docker webhook integration

## Checklist before requesting a review

* [X] I have performed a self-review of my code
* [X] I've added documentation about this change to the README.
* [X] I've not introduced breaking changes.
