### PR TITLE
Fix folder copy on arm images

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -95,7 +95,7 @@ ENV PORT= \
     DISCORD_PRE_SHUTDOWN_MESSAGE="Server is shutting down..." \
     DISCORD_POST_SHUTDOWN_MESSAGE="Server has been stopped!"
 
-COPY ./scripts/* /home/steam/server/
+COPY ./scripts /home/steam/server/
 
 RUN chmod +x /home/steam/server/*.sh && \
     mv /home/steam/server/backup.sh /usr/local/bin/backup && \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -44,6 +44,7 @@ LABEL maintainer="thijs@loef.dev" \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     procps=2:3.3.17-5 \
     wget=1.21-1+deb11u1 \
+    gettext-base=0.21-4 \
     xdg-user-dirs=0.17-2 \
     jo=1.3-2 \
     && apt-get clean \


### PR DESCRIPTION
Fixing a bug where the scripts folder structure isnt copied exactly resulting in the files folder missing.