### PR TITLE
Replace `:latest` uses with the specific latest supported version

### DIFF
--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: palworld
-version: 0.24.1
+version: 0.24.2
 description: This chart will provide a Palworld server installation on a kubernetes cluster
 type: application
 keywords:

--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -30,7 +30,7 @@ annotations:
       url: https://github.com/thijsvanloef/palworld-server-docker
   artifacthub.io/images: |
     - name: palworld-server-docker
-      image: thijsvanloef/palworld-server-docker:0.24.1
+      image: thijsvanloef/palworld-server-docker:0.24.2
   artifacthub.io/screenshots: |
     - title: PalWorld
       url: https://cdn.akamai.steamstatic.com/steam/apps/1623730/header.jpg

--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,7 +1,6 @@
----
 apiVersion: v2
 name: palworld
-version: 0.1.0
+version: 0.24.1
 description: This chart will provide a Palworld server installation on a kubernetes cluster
 type: application
 keywords:
@@ -31,7 +30,7 @@ annotations:
       url: https://github.com/thijsvanloef/palworld-server-docker
   artifacthub.io/images: |
     - name: palworld-server-docker
-      image: thijsvanloef/palworld-server-docker:latest
+      image: thijsvanloef/palworld-server-docker:0.24.1
   artifacthub.io/screenshots: |
     - title: PalWorld
       url: https://cdn.akamai.steamstatic.com/steam/apps/1623730/header.jpg

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -34,7 +34,7 @@ server:
     # -- Repository of the image, without the tag.
     repository: thijsvanloef/palworld-server-docker
     # -- The tag of the image.
-    tag: latest
+    tag: 0.24.1
     # -- Define the pull policy for the server image.
     imagePullPolicy: IfNotPresent
 

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -34,7 +34,7 @@ server:
     # -- Repository of the image, without the tag.
     repository: thijsvanloef/palworld-server-docker
     # -- The tag of the image.
-    tag: 0.24.1
+    tag: 0.24.2
     # -- Define the pull policy for the server image.
     imagePullPolicy: IfNotPresent
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   palworld:
-    image: thijsvanloef/palworld-server-docker:0.24.1
+    image: thijsvanloef/palworld-server-docker:0.24.2
     restart: unless-stopped
     container_name: palworld-server
     stop_grace_period: 30s  # Set to however long you are willing to wait for the container to gracefully stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   palworld:
-    image: thijsvanloef/palworld-server-docker:latest
+    image: thijsvanloef/palworld-server-docker:0.24.1
     restart: unless-stopped
     container_name: palworld-server
     stop_grace_period: 30s  # Set to however long you are willing to wait for the container to gracefully stop

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: palworld-server
-          image: thijsvanloef/palworld-server-docker:0.24.1
+          image: thijsvanloef/palworld-server-docker:0.24.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8211

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: palworld-server
-          image: thijsvanloef/palworld-server-docker
+          image: thijsvanloef/palworld-server-docker:0.24.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8211


### PR DESCRIPTION
# Motivations
To prevent breaking-changes leaking into our suggested docker-compose and more importantly our helm-chart, we should be using the latest supported version of the docker image, not `:latest`

# Modifications
- Bump the helm-chart version to `0.24.1`, to match the docker-image version
- Replace `:latest`: with the true-latest supported version, `0.24.1`, in our example docker-compose, helm-chart, and k8s example
