### PR TITLE
Add page size checker before running steamcmd for ARM64 images

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -60,6 +60,18 @@ printf "\e[0;32m*****GENERATING CONFIGS*****\e[0m\n"
 
 cd /palworld || exit
 
+# Get the architecture using dpkg
+architecture=$(dpkg --print-architecture)
+
+# Get host kernel page size
+kernel_page_size=$(getconf PAGESIZE)
+
+# Check kernel page size for arm64 hosts before running steamcmd
+if [ "$architecture" == "arm64" ] && [ "$kernel_page_size" != "4096" ]; then
+    echo "Only ARM64 hosts with 4k page size is supported."
+    exit 1
+fi
+
 if [ "${UPDATE_ON_BOOT,,}" = true ]; then
     printf "\e[0;32m%s\e[0m\n" "*****STARTING INSTALL/UPDATE*****"
 
@@ -74,8 +86,6 @@ if [ "${UPDATE_ON_BOOT,,}" = true ]; then
     fi
 fi
 
-# Get the architecture using dpkg
-architecture=$(dpkg --print-architecture)
 # Check if the architecture is arm64
 if [ "$architecture" == "arm64" ]; then
     # create an arm64 version of ./PalServer.sh


### PR DESCRIPTION
PR-ing again. Didn't realize PRs get closed if I delete my own fork, my bad.

Kernel page size should be checked before running steamcmd. Box86 (and other compatibility layers for ARM64) only supports 4K page size. Let me know if this should be documented on the README as well.