### PR TITLE
File checks for config generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,8 +74,7 @@ ENV PORT= \
     DISCORD_POST_UPDATE_BOOT_MESSAGE="Server update complete!" \
     DISCORD_PRE_START_MESSAGE="Server has been started!" \
     DISCORD_PRE_SHUTDOWN_MESSAGE="Server is shutting down..." \
-    DISCORD_POST_SHUTDOWN_MESSAGE="Server has been stopped!" \
-    SERVER_PATH="/home/steam/server"
+    DISCORD_POST_SHUTDOWN_MESSAGE="Server has been stopped!"
 
 COPY ./scripts /home/steam/server/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ ENV PORT= \
     DISCORD_POST_UPDATE_BOOT_MESSAGE="Server update complete!" \
     DISCORD_PRE_START_MESSAGE="Server has been started!" \
     DISCORD_PRE_SHUTDOWN_MESSAGE="Server is shutting down..." \
-    DISCORD_POST_SHUTDOWN_MESSAGE="Server has been stopped!"
+    DISCORD_POST_SHUTDOWN_MESSAGE="Server has been stopped!" \
+    SERVER_PATH="/home/steam/server"
 
 COPY ./scripts /home/steam/server/
 

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck source=scripts/helper_functions.sh
-source "/home/steam/server/helper_functions.sh"
+source "helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -8,7 +8,7 @@ mkdir -p "$config_dir" || exit
 # If file exists then check if it is writable
 if fileExists "$config_file" > /dev/null; then
     if ! isWritable "$config_file"; then
-        echo "Not writable"
+        echo "Unable to create $config_file"
         exit 1
     fi
 # If file does not exist then check if the directory is writable

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck source=/dev/null
-. "${SERVER_PATH}/helper_functions.sh"
+source "/home/steam/server/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -3,6 +3,8 @@
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")
 
+mkdir -p "$config_dir" || exit
+
 echo "Compiling PalWorldSettings.ini..."
 
 export DIFFICULTY=${DIFFICULTY:-None}
@@ -137,7 +139,6 @@ BAN_LIST_URL = $BAN_LIST_URL
 EOF
 fi
 
-mkdir -p "$config_dir"
 cat > "$config_file" <<EOF
 [/Script/Pal.PalGameWorldSettings]
 $(envsubst < ./files/PalWorldSettings.ini.template | tr -d "\n\r")

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=scripts/helper_functions.sh
+# shellcheck source=/dev/null
 . "${SERVER_PATH}/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck source=scripts/helper_functions.sh
 source /home/steam/server/helper_functions.sh
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -6,7 +6,7 @@ config_dir=$(dirname "$config_file")
 
 mkdir -p "$config_dir" || exit
 # If file exists then check if it is writable
-if fileExists "$config_file" > /dev/null; then
+if [ -f "$config_file" ]; then
     if ! isWritable "$config_file"; then
         echo "Unable to create $config_file"
         exit 1

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# shellcheck source=scripts/helper_functions.sh
-source "helper_functions.sh"
+# shellcheck source=/dev/null
+source "/home/steam/server/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
+config_dir=$(dirname "$config_file")
+
 echo "Compiling PalWorldSettings.ini..."
 
 export DIFFICULTY=${DIFFICULTY:-None}
@@ -134,8 +137,8 @@ BAN_LIST_URL = $BAN_LIST_URL
 EOF
 fi
 
-mkdir -p /palworld/Pal/Saved/Config/LinuxServer
-cat > /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini <<EOF
+mkdir -p "$config_dir"
+cat > "$config_file" <<EOF
 [/Script/Pal.PalGameWorldSettings]
 $(envsubst < ./files/PalWorldSettings.ini.template | tr -d "\n\r")
 EOF

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# shellcheck source-path=scripts
-source "helper_functions.sh"
+# shellcheck source=/dev/null
+source "/home/steam/server/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck source-path=scripts
-source "/home/steam/server/helper_functions.sh"
+source "helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck source=scripts/helper_functions.sh
-source "/home/steam/server/helper_functions.sh"
+source "${SERVER_PATH}/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck source=scripts/helper_functions.sh
-source /home/steam/server/helper_functions.sh
+source "/home/steam/server/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck source=scripts/helper_functions.sh
-source "${SERVER_PATH}/helper_functions.sh"
+. "${SERVER_PATH}/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source-path=scripts
 source "/home/steam/server/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
+source /home/steam/server/helper_functions.sh
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
 config_dir=$(dirname "$config_file")
 
 mkdir -p "$config_dir" || exit
+# If file exists then check if it is writable
+if fileExists "$config_file" > /dev/null; then
+    if ! isWritable "$config_file"; then
+        echo "Not writable"
+        exit 1
+    fi
+# If file does not exist then check if the directory is writable
+elif ! isWritable "$config_dir"; then
+    # Exiting since the file does not exist and the directory is not writable.
+    echo "Unable to create $config_file"
+    exit 1
+fi
 
 echo "Compiling PalWorldSettings.ini..."
 

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This file contains functions which can be used in multiple scripts
+
+dirExists() {
+    local path="$1"
+    local return_val=0
+    if ! [ -d "${path}" ]; then
+        echo "${path} does not exist."
+        return_val=1
+    fi
+    return "$return_val"
+}
+
+fileExists() {
+    local path="$1"
+    local return_val=0
+    if ! [ -f "${path}" ]; then
+        echo "${path} does not exist."
+        return_val=1
+    fi
+    echo "Return code: $return_val"
+    return "$return_val"
+}
+
+isReadable() {
+    local path="$1"
+    local return_val=0
+    if ! [ -e "${path}" ]; then
+        echo "${path} is not readable."
+        return_val=1
+    fi
+    return "$return_val"
+}
+
+isWritable() {
+    local path="$1"
+    local return_val=0
+    if ! [ -w "${path}" ]; then
+        echo "${path} is not writable."
+        return_val=1
+    fi
+    return "$return_val"
+}
+
+isExecutable() {
+    local path="$1"
+    local return_val=0
+    if ! [ -x "${path}" ]; then
+        echo "${path} is not executable."
+        return_val=1
+    fi
+    return "$return_val"
+}

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -18,7 +18,6 @@ fileExists() {
         echo "${path} does not exist."
         return_val=1
     fi
-    echo "Return code: $return_val"
     return "$return_val"
 }
 

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This file contains functions which can be used in multiple scripts
 
+# Checks if a given path is a directory
+# Returns 0 if the path is a directory
+# Returns 1 if the path is not a directory or does not exists and produces an output message
 dirExists() {
     local path="$1"
     local return_val=0
@@ -11,6 +14,9 @@ dirExists() {
     return "$return_val"
 }
 
+# Checks if a given path is a regular file
+# Returns 0 if the path is a regular file
+# Returns 1 if the path is not a regular file or does not exists and produces an output message
 fileExists() {
     local path="$1"
     local return_val=0
@@ -21,6 +27,9 @@ fileExists() {
     return "$return_val"
 }
 
+# Checks if a given path exists and is readable
+# Returns 0 if the path exists and is readable
+# Returns 1 if the path is not readable or does not exists and produces an output message
 isReadable() {
     local path="$1"
     local return_val=0
@@ -31,6 +40,9 @@ isReadable() {
     return "$return_val"
 }
 
+# Checks if a given path is writable
+# Returns 0 if the path is writable
+# Returns 1 if the path is not writable or does not exists and produces an output message
 isWritable() {
     local path="$1"
     local return_val=0
@@ -41,6 +53,9 @@ isWritable() {
     return "$return_val"
 }
 
+# Checks if a given path is executable
+# Returns 0 if the path is executable
+# Returns 1 if the path is not executable or does not exists and produces an output message
 isExecutable() {
     local path="$1"
     local return_val=0

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck source=scripts/helper_functions.sh
-source "/home/steam/server/helper_functions.sh"
+source "${SERVER_PATH}/helper_functions.sh"
 
 dirExists "/palworld" || exit
 isWritable "/palworld" || exit

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck source=scripts/helper_functions.sh
-source "${SERVER_PATH}/helper_functions.sh"
+. "${SERVER_PATH}/helper_functions.sh"
 
 dirExists "/palworld" || exit
 isWritable "/palworld" || exit

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# shellcheck source=scripts/helper_functions.sh
-. "${SERVER_PATH}/helper_functions.sh"
+# shellcheck source=/dev/null
+source "/home/steam/server/helper_functions.sh"
 
 dirExists "/palworld" || exit
 isWritable "/palworld" || exit

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck source=scripts/helper_functions.sh
-source /home/steam/server/helper_functions.sh
+source "/home/steam/server/helper_functions.sh"
 
 dirExists "/palworld" || exit
 isWritable "/palworld" || exit

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,54 +1,5 @@
 #!/bin/bash
-
-dirExists() {
-    local path="$1"
-    local return_val=0
-    if ! [ -d "${path}" ]; then
-        echo "${path} does not exist."
-        return_val=1
-    fi
-    return "$return_val"
-}
-
-fileExists() {
-    local path="$1"
-    local return_val=0
-    if ! [ -f "${path}" ]; then
-        echo "${path} does not exist."
-        return_val=1
-    fi
-    return "$return_val"
-}
-
-isReadable() {
-    local path="$1"
-    local return_val=0
-    if ! [ -e "${path}" ]; then
-        echo "${path} is not readable."
-        return_val=1
-    fi
-    return "$return_val"
-}
-
-isWritable() {
-    local path="$1"
-    local return_val=0
-    if ! [ -w "${path}" ]; then
-        echo "${path} is not writable."
-        return_val=1
-    fi
-    return "$return_val"
-}
-
-isExecutable() {
-    local path="$1"
-    local return_val=0
-    if ! [ -x "${path}" ]; then
-        echo "${path} is not executable."
-        return_val=1
-    fi
-    return "$return_val"
-}
+source /home/steam/scripts/helper_functions.sh
 
 dirExists "/palworld" || exit
 isWritable "/palworld" || exit

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,7 +7,7 @@ isExecutable "/palworld" || exit
 
 printf "\e[0;32m*****GENERATING CONFIGS*****\e[0m\n"
 
-./compile-settings.sh
+./compile-settings.sh || exit
 
 cd /palworld || exit
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /home/steam/scripts/helper_functions.sh
+source /home/steam/server/helper_functions.sh
 
 dirExists "/palworld" || exit
 isWritable "/palworld" || exit

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck source=scripts/helper_functions.sh
 source /home/steam/server/helper_functions.sh
 
 dirExists "/palworld" || exit


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* #207 removed the error handling when creating the INI file
* Added exiting on error during compile settings

## Choices

* Moved helper functions to their own script so they can be used in other scripts

## Test instructions

1. Verify the container starts as normal
2. Remove the write permissions of the config file `chmod ugo-w palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini`
3. Start the container and verify you get this message `/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini is not writable.` and `Unable to create /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini`
4. Delete the config file and remove write permission from the directory `rm -f palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini && chmod ugo-w palworld/Pal/Saved/Config/LinuxServer/`
5. Start the container and verify you get these messages `/palworld/Pal/Saved/Config/LinuxServer is not writable.` and `Unable to create /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini`
6. Delete the config directory and remove the write permissions of the parent folder `chmod ugo+w palworld/Pal/Saved/Config/LinuxServer/ && rm -rf palworld/Pal/Saved/Config/LinuxServer/ && chmod ugo-w palworld/Pal/Saved/Config`
7. Start the container and verify you get this messages `mkdir: cannot create directory '/palworld/Pal/Saved/Config/LinuxServer': Permission denied`

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
