### PR TITLE
Changed array to map

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,19 +72,19 @@ services:
         - 8211:8211/udp
         - 27015:27015/udp
       environment:
-         - PUID=1000
-         - PGID=1000
-         - PORT=8211 # Optional but recommended
-         - PLAYERS=16 # Optional but recommended
-         - SERVER_PASSWORD=worldofpals # Optional but recommended
-         - MULTITHREADING=true
-         - RCON_ENABLED=true
-         - RCON_PORT=25575
-         - TZ=UTC
-         - ADMIN_PASSWORD=adminPasswordHere
-         - COMMUNITY=false  # Enable this if you want your server to show up in the community servers tab, USE WITH SERVER_PASSWORD!
-         - SERVER_NAME=World of Pals
-         - SERVER_DESCRIPTION=palworld-server-docker by Thijs van Loef
+         PUID: 1000
+         PGID: 1000
+         PORT: 8211 # Optional but recommended
+         PLAYERS: 16 # Optional but recommended
+         SERVER_PASSWORD: "worldofpals" # Optional but recommended
+         MULTITHREADING: true
+         RCON_ENABLED: true
+         RCON_PORT: 25575
+         TZ: "UTC"
+         ADMIN_PASSWORD: "adminPasswordHere"
+         COMMUNITY: false  # Enable this if you want your server to show up in the community servers tab, USE WITH SERVER_PASSWORD!
+         SERVER_NAME: "World of Pals"
+         SERVER_DESCRIPTION: "palworld-server-docker by Thijs van Loef"
       volumes:
          - ./palworld:/palworld/
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,18 +9,18 @@ services:
       - 8211:8211/udp
       - 27015:27015/udp  # Required if you want your server to show up in the community servers tab
     environment:
-      - PUID=1000
-      - PGID=1000
-      - PORT=8211  # Optional but recommended
-      - PLAYERS=16  # Optional but recommended
-      - SERVER_PASSWORD=worldofpals  # Optional but recommended
-      - MULTITHREADING=true
-      - RCON_ENABLED=true
-      - RCON_PORT=25575
-      - TZ=UTC
-      - ADMIN_PASSWORD=adminPasswordHere
-      - COMMUNITY=false  # Enable this if you want your server to show up in the community servers tab, USE WITH SERVER_PASSWORD!
-      - SERVER_NAME=World of Pals
-      - SERVER_DESCRIPTION=palworld-server-docker by Thijs van Loef
+      PUID: 1000
+      PGID: 1000
+      PORT: 8211  # Optional but recommended
+      PLAYERS: 16  # Optional but recommended
+      SERVER_PASSWORD: "worldofpals"  # Optional but recommended
+      MULTITHREADING: true
+      RCON_ENABLED: true
+      RCON_PORT: 25575
+      TZ: UTC
+      ADMIN_PASSWORD: "adminPasswordHere"
+      COMMUNITY: false  # Enable this if you want your server to show up in the community servers tab, USE WITH SERVER_PASSWORD!
+      SERVER_NAME: "World of Pals"
+      SERVER_DESCRIPTION: "palworld-server-docker by Thijs van Loef"
     volumes:
       - ./palworld:/palworld/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       MULTITHREADING: true
       RCON_ENABLED: true
       RCON_PORT: 25575
-      TZ: UTC
+      TZ: "UTC"
       ADMIN_PASSWORD: "adminPasswordHere"
       COMMUNITY: false  # Enable this if you want your server to show up in the community servers tab, USE WITH SERVER_PASSWORD!
       SERVER_NAME: "World of Pals"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

[Docker Documentation](https://docs.docker.com/compose/compose-file/05-services/#environment) doesn't support `var="value"` but rather:
* `var: "value"`
* `var: value`
* `var=value`
It is worth noting that you can do `"var=value"` but it's not mentioned

* People keep using quotes in array declaration of environmental variables. Changes array to map which docker compose supports the use of quotes
* Currently `- SERVER_NAME="World of Pals"` appears as `"World of Pals"`
* Currently `- SERVER_NAME=World of Pals` appears as `World of Pals`

## Choices

* By switching to a map `SERVER_NAME: "World of Pals"` appears as `World of Pals`
*  `SERVER_NAME: World of Pals` appears as `World of Pals`
* Using maps also aligns our docker compose to be more align with k8s folder yamls as those tend to use maps (Ideally this would be in spell check somehow)

## Test instructions

1. Start the container
2. Verify using quotes does not add quotes around variables `docker exec -it palworld-server bash -c 'echo $SERVER_NAME'`

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
