### PR TITLE
feat: chart: allow specifying imagePullSecrets

### DIFF
--- a/charts/palworld/Chart.yaml
+++ b/charts/palworld/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: palworld
-version: 0.1.0
+version: 0.1.1
 description: This chart will provide a Palworld server installation on a kubernetes cluster
 type: application
 keywords:

--- a/charts/palworld/templates/deployments.yaml
+++ b/charts/palworld/templates/deployments.yaml
@@ -67,6 +67,10 @@ spec:
           volumeMounts:
             - mountPath: /palworld
               name: datadir
+      {{- with .Values.server.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: datadir
           persistentVolumeClaim:

--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -37,6 +37,8 @@ server:
     tag: latest
     # -- Define the pull policy for the server image.
     imagePullPolicy: IfNotPresent
+    # -- Define the pull secrets for the server image.
+    imagePullSecrets: []
 
   # -- (dict) Change the ports to be mapped to the pod.
   # If you change those, make sure to change the service.ports and server.config accordingly.


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Allow specifying `imagePullSecrets` due to the Docker Hub ratelimit
* Related: #353

## Choices

* Docker Hub's rate limit is easily hit when running a large Kubernetes cluster, therefore it's prudent to allow users of the chart to authenticate to raise the rate limit.

## Test instructions

1. `helm template palworld ./palworld/ -f ./palworld/values.yaml --set 'server.image.imagePullSecrets[0].name=registry-docker-hub'` then verified the `imagePullSecrets` on the Deployment was valid

## Checklist before requesting a review

* [X] I have performed a self-review of my code
* [X] I've added documentation about this change to the README.
* [X] I've not introduced breaking changes.
