### PR TITLE
fix: chart: RCON is a TCP-based protocol

### DIFF
--- a/charts/palworld/values.yaml
+++ b/charts/palworld/values.yaml
@@ -56,7 +56,7 @@ server:
     # If you change this, make sure to change the service.ports.rcon and server.config accordingly.
     - name: rcon
       containerPort: 25575
-      protocol: UDP
+      protocol: TCP
   # -- (string) Change the deployment strategy
   strategy: Recreate
 
@@ -102,7 +102,7 @@ server:
       # If you change this, make sure to change the server.ports.rcon and server.config.rcon.port accordingly.
       - name: rcon
         port: 25575
-        protocol: UDP
+        protocol: TCP
         targetPort: 25575
   # -- (dict) Change the game server configuration.
   # If you change those, make sure to change the service.ports and server.ports accordingly.


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Fixes the default chart values to use the appropriate protocol for RCON

## Choices

* RCON is on TCP not UDP

## Test instructions

1. Deployed in https://github.com/USA-RedDragon/home-cluster-flux/commit/ca34e5318fac7d88a2ea9e414e9dae5578bf0415

## Checklist before requesting a review

* [X] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [X] I've not introduced breaking changes.
