### PR TITLE
Wait for the server to shutdown before restoring a backup

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -109,6 +109,7 @@ if [ -f "$BACKUP_FILE" ]; then
             # Decompress the backup file in tmp directory
             tar -zxvf "$BACKUP_FILE" -C "$TMP_PATH"
 
+            # Make sure Saves with a different ID are removed before restoring the save
             rm -rf "$RESTORE_PATH/Saved/"
 
             # Move the backup file to the restore directory

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -67,6 +67,12 @@ if [ -f "$BACKUP_FILE" ]; then
             echo "RCON is not enabled. Please enable RCON to use this feature. Unable to restore backup."
             exit 1
         fi
+
+        while [ -n "$(pidof PalServer-Linux-Test)" ] 
+        do
+            echo "Waiting for Palworld to exit.."
+            sleep 1
+        done
         printf "\e[0;32mShutdown complete.\e[0m\n"
 
         trap - ERR
@@ -102,6 +108,8 @@ if [ -f "$BACKUP_FILE" ]; then
             
             # Decompress the backup file in tmp directory
             tar -zxvf "$BACKUP_FILE" -C "$TMP_PATH"
+
+            rm -rf "$RESTORE_PATH/Saved/"
 
             # Move the backup file to the restore directory
             \cp -rf -f "$TMP_PATH/Saved/" "$RESTORE_PATH"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* The restore script does not wait for the server to actually shut down
* Because of this Settings are reverted after the server restarts
* Closes #359 

## Choices

* Getting the PID of the PalServer-Linux-Test binary to test if it is still running
* Continue with the restore only after the server has shutdown

## Test instructions

1. Start a Server
2. Create a backup
3. Extract the backup and change the id in `/palworld/Pal/Saved/Config/LinuxServer/GameUserSettings.ini`
4. Rename the directory in `/palworld/Pal/Saved/SaveGames/0/` to the ID in GameUserSettings.ini
5. Tar the 'Saved' directory again
6. Run the restore command `docker exec -it palworld-server restore`
7. Select the backup which was altered
8. Verify that the server has restarted
9. Verify that the ID in GameUserSettings.ini is the same which was used in the backup
10. Verify that the directory in `/palworld/Pal/Saved/SaveGames/0/` has the correct name

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
