### PR TITLE
Added exit on bad crontab

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -95,21 +95,26 @@ else
   /home/steam/server/compile-settings.sh
 fi
 
+printf "\e[0;32m%s\e[0m\n" "*****GENERATING CRONTAB*****"
+
 rm -f  "/home/steam/server/crontab"
 if [ "${BACKUP_ENABLED,,}" = true ]; then
     echo "BACKUP_ENABLED=${BACKUP_ENABLED,,}"
+    echo "Adding cronjob for auto backups"
     echo "$BACKUP_CRON_EXPRESSION bash /usr/local/bin/backup" >> "/home/steam/server/crontab"
     supercronic -quiet -test "/home/steam/server/crontab" || exit
 fi
 
 if [ "${AUTO_UPDATE_ENABLED,,}" = true ] && [ "${UPDATE_ON_BOOT}" = true ]; then
     echo "AUTO_UPDATE_ENABLED=${AUTO_UPDATE_ENABLED,,}"
+    echo "Adding cronjob for auto updating"
     echo "$AUTO_UPDATE_CRON_EXPRESSION bash /usr/local/bin/update" >> "/home/steam/server/crontab"
     supercronic -quiet -test "/home/steam/server/crontab" || exit
 fi
 
 if [ "${AUTO_REBOOT_ENABLED,,}" = true ] && [ "${RCON_ENABLED,,}" = true ]; then
     echo "AUTO_REBOOT_ENABLED=${AUTO_REBOOT_ENABLED,,}"
+    echo "Adding cronjob for auto rebooting"
     echo "$AUTO_REBOOT_CRON_EXPRESSION bash /home/steam/server/auto_reboot.sh" >> "/home/steam/server/crontab"
     supercronic -quiet -test "/home/steam/server/crontab" || exit
 fi
@@ -117,6 +122,9 @@ fi
 if { [ "${AUTO_UPDATE_ENABLED,,}" = true ] && [ "${UPDATE_ON_BOOT,,}" = true ]; } || [ "${BACKUP_ENABLED,,}" = true ] || \
     [ "${AUTO_REBOOT_ENABLED,,}" = true ]; then
     supercronic "/home/steam/server/crontab" &
+    echo "Cronjobs started"
+else
+    echo "No Cronjobs found"
 fi
 
 # Configure RCON settings

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -99,16 +99,19 @@ rm -f  "/home/steam/server/crontab"
 if [ "${BACKUP_ENABLED,,}" = true ]; then
     echo "BACKUP_ENABLED=${BACKUP_ENABLED,,}"
     echo "$BACKUP_CRON_EXPRESSION bash /usr/local/bin/backup" >> "/home/steam/server/crontab"
+    supercronic -quiet -test "/home/steam/server/crontab" || exit
 fi
 
 if [ "${AUTO_UPDATE_ENABLED,,}" = true ] && [ "${UPDATE_ON_BOOT}" = true ]; then
     echo "AUTO_UPDATE_ENABLED=${AUTO_UPDATE_ENABLED,,}"
     echo "$AUTO_UPDATE_CRON_EXPRESSION bash /usr/local/bin/update" >> "/home/steam/server/crontab"
+    supercronic -quiet -test "/home/steam/server/crontab" || exit
 fi
 
 if [ "${AUTO_REBOOT_ENABLED,,}" = true ] && [ "${RCON_ENABLED,,}" = true ]; then
     echo "AUTO_REBOOT_ENABLED=${AUTO_REBOOT_ENABLED,,}"
     echo "$AUTO_REBOOT_CRON_EXPRESSION bash /home/steam/server/auto_reboot.sh" >> "/home/steam/server/crontab"
+    supercronic -quiet -test "/home/steam/server/crontab" || exit
 fi
 
 if { [ "${AUTO_UPDATE_ENABLED,,}" = true ] && [ "${UPDATE_ON_BOOT,,}" = true ]; } || [ "${BACKUP_ENABLED,,}" = true ] || \


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* People have no way of knowing if their cron expressions are bad.

## Choices

* Checking after each addition to the crontab since the test breaks on the first invalid expression
* Also makes it easier to understand which expression broke as I added  

## Test instructions

1. Start the container and should see new section in output
     ```
     palworld-server-test  | *****GENERATING CRONTAB*****
     palworld-server-test  | BACKUP_ENABLED=true
     palworld-server-test  | Adding cronjob for auto backups
     palworld-server-test  | AUTO_UPDATE_ENABLED=true
     palworld-server-test  | Adding cronjob for auto updating
     palworld-server-test  | AUTO_REBOOT_ENABLED=true
     palworld-server-test  | Adding cronjob for auto rebooting
     palworld-server-test  | Cronjobs started
     ```
2. Start with all cron jobs disabled
     ```
     palworld-server-test  | *****GENERATING CRONTAB*****
     palworld-server-test  | No Cronjobs found
     ```
3. Try with an invalid cron expression
    ```
    palworld-server-test  | *****GENERATING CRONTAB*****
    palworld-server-test  | BACKUP_ENABLED=true
    palworld-server-test  | Adding cronjob for auto backups
    palworld-server-test  | AUTO_UPDATE_ENABLED=true
    palworld-server-test  | Adding cronjob for auto updating
    palworld-server-test  | time="2024-02-13T18:01:54Z" level=fatal msg="bad crontab line: 'FOOBAR bash 
    /usr/local/bin/update' (use -debug for details)"
    palworld-server-test exited with code 0
    ```


## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
