### PR TITLE
Add save and shutdown functions

### DIFF
--- a/scripts/auto_reboot.sh
+++ b/scripts/auto_reboot.sh
@@ -20,7 +20,6 @@ if [ "${RCON_ENABLED,,}" = true ]; then
             sleep "1m"
         done
 
-        save_server
         shutdown_server
     else
         echo "Unable to auto reboot, AUTO_REBOOT_WARN_MINUTES is not an integer: ${AUTO_REBOOT_WARN_MINUTES}"

--- a/scripts/auto_reboot.sh
+++ b/scripts/auto_reboot.sh
@@ -20,7 +20,7 @@ if [ "${RCON_ENABLED,,}" = true ]; then
             sleep "1m"
         done
 
-        rcon-cli -c /home/steam/server/rcon.yaml save
+        save_server
         rcon-cli -c /home/steam/server/rcon.yaml "shutdown 1"
     else
         echo "Unable to auto reboot, AUTO_REBOOT_WARN_MINUTES is not an integer: ${AUTO_REBOOT_WARN_MINUTES}"

--- a/scripts/auto_reboot.sh
+++ b/scripts/auto_reboot.sh
@@ -21,7 +21,7 @@ if [ "${RCON_ENABLED,,}" = true ]; then
         done
 
         save_server
-        rcon-cli -c /home/steam/server/rcon.yaml "shutdown 1"
+        shutdown_server
     else
         echo "Unable to auto reboot, AUTO_REBOOT_WARN_MINUTES is not an integer: ${AUTO_REBOOT_WARN_MINUTES}"
     fi

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -4,9 +4,7 @@ if [ -n "${DISCORD_WEBHOOK_URL}" ]; then
     /home/steam/server/discord.sh "Creating backup..." "in-progress" &
 fi
 
-if [ "${RCON_ENABLED,,}" = true ]; then
-    rcon-cli -c /home/steam/server/rcon.yaml save
-fi
+save_server
 
 DATE=$(date +"%Y-%m-%d_%H-%M-%S")
 FILE_PATH="/palworld/backups/palworld-save-${DATE}.tar.gz"

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -91,3 +91,16 @@ save_server() {
     fi
     return "$return_val"
 }
+
+# Shutdowns the server
+# Returns 0 if it is shutdown
+# Returns 1 if it is not able to be shutdown
+shutdown_server() {
+    local return_val=0
+    if [ "${RCON_ENABLED,,}" = true ]; then
+        shutdown_server
+    else
+        return_val=1
+    fi
+    return "$return_val"
+}

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -92,13 +92,18 @@ save_server() {
     return "$return_val"
 }
 
-# Shutdowns the server
+# Saves then shutdowns the server
 # Returns 0 if it is shutdown
 # Returns 1 if it is not able to be shutdown
 shutdown_server() {
     local return_val=0
     if [ "${RCON_ENABLED,,}" = true ]; then
-        shutdown_server
+        # Do not shutdown if not able to save
+        if save_server; then
+            shutdown_server
+        else
+            return_val=1
+        fi
     else
         return_val=1
     fi

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -100,7 +100,7 @@ shutdown_server() {
     if [ "${RCON_ENABLED,,}" = true ]; then
         # Do not shutdown if not able to save
         if save_server; then
-            shutdown_server
+            rcon-cli -c /home/steam/server/rcon.yaml "shutdown 1"
         else
             return_val=1
         fi

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -78,3 +78,16 @@ get_player_count() {
     player_list=$(rcon-cli -c /home/steam/server/rcon.yaml "ShowPlayers")
     echo -n "${player_list}" | wc -l
 }
+
+# Saves the server
+# Returns 0 if it saves
+# Returns 1 if it is not able to save
+save_server() {
+    local return_val=0
+    if [ "${RCON_ENABLED,,}" = true ]; then
+        rcon-cli -c /home/steam/server/rcon.yaml save
+    else
+        return_val=1
+    fi
+    return "$return_val"
+}

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -18,10 +18,8 @@ term_handler() {
         su steam -c "/home/steam/server/discord.sh '${DISCORD_PRE_SHUTDOWN_MESSAGE}' in-progress" &
     fi
 
-    if [ "${RCON_ENABLED,,}" = true ]; then
-        rcon-cli save
-        rcon-cli "shutdown 1"
-    else # Does not save
+    if ! shutdown_server; then
+        # If it fails then kill the server
         kill -SIGTERM "$(pidof PalServer-Linux-Test)"
     fi
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -61,7 +61,6 @@ if [ -f "$BACKUP_FILE" ]; then
 
         if [ "${RCON_ENABLED}" = true ]; then
             printf "\e[0;32m*****SHUTDOWN SERVER*****\e[0m\n"
-            save_server
             shutdown_server
         else
             echo "RCON is not enabled. Please enable RCON to use this feature. Unable to restore backup."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -62,7 +62,7 @@ if [ -f "$BACKUP_FILE" ]; then
         if [ "${RCON_ENABLED}" = true ]; then
             printf "\e[0;32m*****SHUTDOWN SERVER*****\e[0m\n"
             save_server
-            rcon-cli -c /home/steam/server/rcon.yaml "shutdown 1"
+            shutdown_server
         else
             echo "RCON is not enabled. Please enable RCON to use this feature. Unable to restore backup."
             exit 1

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -61,7 +61,7 @@ if [ -f "$BACKUP_FILE" ]; then
 
         if [ "${RCON_ENABLED}" = true ]; then
             printf "\e[0;32m*****SHUTDOWN SERVER*****\e[0m\n"
-            rcon-cli -c /home/steam/server/rcon.yaml save
+            save_server
             rcon-cli -c /home/steam/server/rcon.yaml "shutdown 1"
         else
             echo "RCON is not enabled. Please enable RCON to use this feature. Unable to restore backup."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -52,7 +52,7 @@ if [ "$CURRENT_MANIFEST" != "$TARGET_MANIFEST" ]; then
         sleep "${AUTO_UPDATE_WARN_MINUTES}m"
     fi
     backup
-    rcon-cli -c /home/steam/server/rcon.yaml "shutdown 1"
+    shutdown_server
 else
     echo "The Server is up to date!"
 fi


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* We repeat save and shutdown commands in multiple scripts

## Choices

* If Palworld ever adds a better method to save or shutdown this makes it easier to implement.
* Since #395 intends to add a feature to change the shutdown command from `shutdown 1` to `DoExit` this means changing it in one place.

## Test instructions

1. Test the server still works
2. Verify stopping works
3. Verify updating works
4. Verify backing up works
5. Verify auto_reboot works

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.
