### PR TITLE
Fix Discord Webhook warn levels

### DIFF
--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -120,7 +120,7 @@ Log() {
 DiscordMessage() {
   local message="$1"
   local level="$2"
-  if [ -n "$level" ]; then
+  if [ -z "$level" ]; then
     level="info"
   fi
   if [ -n "${DISCORD_WEBHOOK_URL}" ]; then


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* fixes that the server only sends messages with info level

## Choices


## Test instructions

1. Configure a Webhook in the environment variables
2. Start the server
3. Stop the server
4. Verify that there is sent a message with green and one with red

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
