### PR TITLE
Fix always showing: "Game not at target version"

### DIFF
--- a/scripts/helper_install.sh
+++ b/scripts/helper_install.sh
@@ -91,7 +91,7 @@ UpdateRequired() {
     return 0
   fi
 
-  if [ "$CURRENT_MANIFEST" != "${TARGET_MANIFEST_ID}" ]; then
+  if [ -n "${TARGET_MANIFEST_ID}" ] && [ "$CURRENT_MANIFEST" != "${TARGET_MANIFEST_ID}" ]; then
     LogInfo "Game not at target version. Target Version: ${TARGET_MANIFEST_ID}"
     return 0
   fi


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

With the recent addition of the option to pin the manifest this small bug made its way into the logs.
This change makes sure that the message only appears when needed

## Choices

Added a check to make sure that the manifest is set before checking if it matches the current version

## Test instructions

1. Do not set TARGET_MANIFEST_ID
2. start the server
3. notice that it only displays the message when applicable

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
