### PR TITLE
Fixed image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN chmod +x /home/steam/server/*.sh && \
 WORKDIR /home/steam/server
 RUN touch rcon.yaml crontab && \
     mkdir -p /home/steam/Steam/package && \
+    rm -rf /tmp/dumps && \
     chmod o+w rcon.yaml crontab /home/steam/Steam/package && \
     chown steam:steam -R /home/steam
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN chmod +x /home/steam/server/*.sh && \
 WORKDIR /home/steam/server
 RUN touch rcon.yaml crontab && \
     mkdir -p /home/steam/Steam/package && \
+    chown steam:steam /home/steam/Steam/package && \
     rm -rf /tmp/dumps && \
     chmod o+w rcon.yaml crontab /home/steam/Steam/package && \
     chown steam:steam -R /home/steam/server

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ RUN touch rcon.yaml crontab && \
     mkdir -p /home/steam/Steam/package && \
     rm -rf /tmp/dumps && \
     chmod o+w rcon.yaml crontab /home/steam/Steam/package && \
-    chown steam:steam -R /home/steam
+    chown steam:steam -R /home/steam/server
 
 HEALTHCHECK --start-period=5m \
     CMD pgrep "PalServer-Linux" > /dev/null || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,8 @@ RUN case ${TARGETARCH} in \
     && chmod +x supercronic \
     && mv supercronic /usr/local/bin/supercronic
 
-ENV PORT= \
+ENV HOME=/home/steam \
+    PORT= \
     PUID=1000 \
     PGID=1000 \
     PLAYERS= \
@@ -110,9 +111,9 @@ RUN chmod +x /home/steam/server/*.sh && \
 
 WORKDIR /home/steam/server
 RUN touch rcon.yaml crontab && \
-    chmod o+w rcon.yaml crontab && \
-    chown steam:steam -R /home/steam && \
-    chmod -R o+w /home/steam/steamcmd
+    mkdir -p /home/steam/Steam/package && \
+    chmod o+w rcon.yaml crontab /home/steam/Steam/package && \
+    chown steam:steam -R /home/steam
 
 HEALTHCHECK --start-period=5m \
     CMD pgrep "PalServer-Linux" > /dev/null || exit 1


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Reduces image size
* Also delete /tmp/dumps to remove this error when starting as nonroot and a user which does not have a UID of 1000 `/tmp/dumps is not owned by us - delete and recreate`

## Choices

Previously we changed the permission of `/home/steam/steamcmd/` which resulted in an image size increase of 300MB. Now making the directory we need and changing it's permission

## Test instructions

1. Test that is runs with the default compose
2. Test as user 1000:1000
3. Test as any other user

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
