### PR TITLE
add trivy security scanning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 ---
 name: Release
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   release:
     types: [published]
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'security'
+          image-ref: 'thijsvanloef/palworld-server-docker:v0.1'
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   container-scanning:
-    name: Security - Container Scan
+    name: Container - Scan
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,6 +2,8 @@
 name: Security
 on:  # yamllint disable-line rule:truthy
   pull_request:
+  schedule:
+    - cron: 0 0 * * *
 
 jobs:
   container-scanning:
@@ -25,7 +27,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'thijsvanloef/palworld-server-docker:v0.1'
+          image-ref: 'security'
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,6 @@
+---
 name: Security
-on: 
+on:  # yamllint disable-line rule:truthy
   pull_request:
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,35 @@
+name: Security
+on: 
+  pull_request:
+
+jobs:
+  container-scanning:
+    name: Security - Container Scan
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v5
+        with:
+          file: ./Dockerfile
+          load: true
+          tags: security
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'security'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ palworld
 !charts/*
 values*.yaml
 .env
+.vscode


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

Add Security scanning that automatically uploads security advisories to github.

## Choices

* <!-- * Why did you solve it like this? -->

## Test instructions

Open PR, check that container scan runs

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
