### PR TITLE
Add shellcheckrc

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Shellcheck
         uses: ludeeus/action-shellcheck@2.0.0
-        with:
-          config_file: .shellcheckrc
 
   dockerlint:
     name: Lint - Docker

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Shellcheck
         uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          config_file: .shellcheckrc
 
   dockerlint:
     name: Lint - Docker

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/scripts/auto_reboot.sh
+++ b/scripts/auto_reboot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
 if [ "${RCON_ENABLED,,}" != true ]; then

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
 DiscordMessage "Creating backup..." "in-progress"

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
 config_file="/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"

--- a/scripts/discord.sh
+++ b/scripts/discord.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
 # Defaults

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -135,5 +135,5 @@ RCON() {
 }
 
 # Helper Functions for installation & updates
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_install.sh
 source "/home/steam/server/helper_install.sh"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
 if [[ "$(id -u)" -eq 0 ]] && [[ "$(id -g)" -eq 0 ]]; then

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
 # Backup file directory path

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
 dirExists "/palworld" || exit

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck source=/dev/null
+# shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
 UpdateRequired


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* For all bash scripts which use `source` we must tell the linter to ignore it with `# shellcheck source=/dev/null`

## Choices

* Added .shellcheckrc so we properly tell the linter the source of the file per [SC1091](https://github.com/koalaman/shellcheck/wiki/SC1091)

## Test instructions

N/A

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
