### PR TITLE
Change github/codeql-action/upload-sarif to v3

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,6 +34,6 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* CodeQL Action v2 will be deprecated on December 5th, 2024. We currently get a warning in security because of this.

## Choices

* Update now so we remove the warning instead of waiting till December 5th.

## Test instructions
N/A

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
