### PR TITLE
Surpressing broadcast  output

### DIFF
--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -170,7 +170,7 @@ broadcast_command() {
     if [[ $TEXT = *[![:ascii:]]* ]]; then
         LogWarn "Unable to broadcast since the message contains non-ascii characters: \"${message}\""
         return_val=1
-    elif ! RCON "broadcast ${message}"; then
+    elif ! RCON "broadcast ${message}" > /dev/null; then
         return_val=1
     fi
     return "$return_val"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

The function broadcast command returns the result of rcon-cli. So a two minute reboot timer shows
```
palworld-server  | time="2024-02-21T17:33:00-05:00" level=info msg=starting iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="33 17 * * *"
palworld-server  | time="2024-02-21T17:33:00-05:00" level=info msg="Broadcasted: The_Server_will_reboot_in_2_minutes" channel=stdout iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="33 17 * * *"
palworld-server  | time="2024-02-21T17:34:00-05:00" level=info msg="Broadcasted: The_Server_will_reboot_in_1_minutes" channel=stdout iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="33 17 * * *"
palworld-server  | time="2024-02-21T17:35:00-05:00" level=info msg="Complete Save" channel=stdout iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="33 17 * * *"
palworld-server  | time="2024-02-21T17:35:00-05:00" level=info msg=Shutdown... channel=stdout iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="33 17 * * *"
palworld-server  | time="2024-02-21T17:35:00-05:00" level=info msg="job succeeded" iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="33 17 * * *"
```

## Choices

Suppressing the returns message for rcon-cli so we see this for reboot with a two minute timer
```
palworld-server  | time="2024-02-21T17:37:00-05:00" level=info msg=starting iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="37 17 * * *"
palworld-server  | time="2024-02-21T17:39:00-05:00" level=info msg="Complete Save" channel=stdout iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="37 17 * * *"
palworld-server  | time="2024-02-21T17:39:00-05:00" level=info msg=Shutdown... channel=stdout iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="37 17 * * *"
palworld-server  | time="2024-02-21T17:39:00-05:00" level=info msg="job succeeded" iteration=0 job.command="bash /home/steam/server/auto_reboot.sh" job.position=0 job.schedule="37 17 * * *"
```

## Test instructions

1. Verify reboot still works
2. Verify update still works
3. If in branch verify player logging still works

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
