### PR TITLE
Add sha1sum check for rcon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG RCON_TGZ_SHA1SUM=33ee8077e66bea6ee097db4d9c923b5ed390d583
 
 WORKDIR /build
 
-# install rcon and supercronic
+# install rcon
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV CGO_ENABLED=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG RCON_TGZ_SHA1SUM=33ee8077e66bea6ee097db4d9c923b5ed390d583
 WORKDIR /build
 
 # install rcon
-SHELL ["/bin/sh", "-o", "pipefail", "-c"]
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 ENV CGO_ENABLED=0
 RUN wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v${RCON_VERSION}.tar.gz -O rcon.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM golang:1.22.0-alpine as rcon-cli_builder
 
 ARG RCON_VERSION="0.10.3"
+ARG RCON_TGZ_SHA1SUM=33ee8077e66bea6ee097db4d9c923b5ed390d583
 
 WORKDIR /build
 
 ENV CGO_ENABLED=0
 RUN wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v${RCON_VERSION}.tar.gz -O rcon.tar.gz \
+    && echo "${RCON_TGZ_SHA1SUM}" rcon.tar.gz | sha1sum -c - \
     && tar -xzvf rcon.tar.gz \
     && rm rcon.tar.gz \
     && mv rcon-cli-${RCON_VERSION}/* ./ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /build
 
 ENV CGO_ENABLED=0
 RUN wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v${RCON_VERSION}.tar.gz -O rcon.tar.gz \
-    && echo "${RCON_TGZ_SHA1SUM}" rcon.tar.gz | sha1sum -c - \
+    && sha1sum -c - <<< "${RCON_TGZ_SHA1SUM} rcon.tar.gz" \
     && tar -xzvf rcon.tar.gz \
     && rm rcon.tar.gz \
     && mv rcon-cli-${RCON_VERSION}/* ./ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,12 @@ ARG RCON_TGZ_SHA1SUM=33ee8077e66bea6ee097db4d9c923b5ed390d583
 
 WORKDIR /build
 
+# install rcon and supercronic
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 ENV CGO_ENABLED=0
 RUN wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v${RCON_VERSION}.tar.gz -O rcon.tar.gz \
-    && sha1sum -c - <<< "${RCON_TGZ_SHA1SUM} rcon.tar.gz" \
+    && echo "${RCON_TGZ_SHA1SUM}" rcon.tar.gz | sha1sum -c - \
     && tar -xzvf rcon.tar.gz \
     && rm rcon.tar.gz \
     && mv rcon-cli-${RCON_VERSION}/* ./ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG RCON_TGZ_SHA1SUM=33ee8077e66bea6ee097db4d9c923b5ed390d583
 WORKDIR /build
 
 # install rcon
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
 ENV CGO_ENABLED=0
 RUN wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v${RCON_VERSION}.tar.gz -O rcon.tar.gz \


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Currently we do not check sha1sum for rcon but we do for supercronic


## Test instructions

1. Test build
2. Change sha1sum and verify it stop building
```
 => ERROR [palworld rcon-cli_builder 3/3] RUN wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v0.10.3.tar.gz -O rcon.tar.gz     && echo "33ee8077e66bea6ee097db4d9c923b5ed390d5  0.8s
------                                                                                                                                                                                             
 > [palworld rcon-cli_builder 3/3] RUN wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v0.10.3.tar.gz -O rcon.tar.gz     && echo "33ee8077e66bea6ee097db4d9c923b5ed390d584" rcon.tar.gz | sha1sum -c -     && tar -xzvf rcon.tar.gz     && rm rcon.tar.gz     && mv rcon-cli-0.10.3/* ./     && rm -rf rcon-cli-0.10.3     && go build -v ./cmd/gorcon:
0.752 sha1sum: WARNING: 1 of 1 computed checksums did NOT match
0.752 rcon.tar.gz: FAILED
------
failed to solve: process "/bin/sh -c wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v${RCON_VERSION}.tar.gz -O rcon.tar.gz     && echo \"${RCON_TGZ_SHA1SUM}\" rcon.tar.gz | sha1sum -c -     && tar -xzvf rcon.tar.gz     && rm rcon.tar.gz     && mv rcon-cli-${RCON_VERSION}/* ./     && rm -rf rcon-cli-${RCON_VERSION}     && go build -v ./cmd/gorcon" did not complete successfully: exit code: 1
```

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
