### PR TITLE
Player Logging Improvement

### DIFF
--- a/scripts/player_logging.sh
+++ b/scripts/player_logging.sh
@@ -13,8 +13,8 @@ get_playername(){
 }
 
 while true; do
-    mapfile -t server_pids < <(pgrep PalServer-Linux)
-    if [ "${#server_pids[@]}" -ne 0 ]; then
+    server_pid=$(pidof PalServer-Linux-Test)
+    if [ -n "${server_pid}" ]; then
         # Player IDs are usally 9 or 10 digits however when a player joins for the first time for a given boot their ID is temporary 00000000 (8x zeros) while loading
         # Player ID is also 00000000 (8x zeros) when in character creation
         mapfile -t current_player_list < <( get_players_list | tail -n +2 | sed '/,00000000,[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/d' | sort )

--- a/scripts/player_logging.sh
+++ b/scripts/player_logging.sh
@@ -12,47 +12,46 @@ get_playername(){
     echo "${player_info}" | sed -E 's/,([0-9]+),[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]//g'
 }
 
-old_player_list=( )
 while true; do
     mapfile -t server_pids < <(pgrep PalServer-Linux)
     if [ "${#server_pids[@]}" -ne 0 ]; then
         # Player IDs are usally 9 or 10 digits however when a player joins for the first time for a given boot their ID is temporary 00000000 (8x zeros) while loading
         # Player ID is also 00000000 (8x zeros) when in character creation
-        mapfile -t new_player_list < <( get_players_list | tail -n +2 | sed '/,00000000,[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/d' )
-        
-        # See players whose states have changed
-        mapfile -t players_change_list < <( printf '%s\n' "${old_player_list[@]}" "${new_player_list[@]}" | sort | uniq -u )
+        mapfile -t current_player_list < <( get_players_list | tail -n +2 | sed '/,00000000,[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/d' | sort )
 
-        # Go through the list of changes
-        for player in "${players_change_list[@]}"; do
-            # Steam ID to check since names are not unique in game
-            player_steamid=$(get_steamid "${player}")
+        # If there are current players then some may have joined
+        if [ "${#current_player_list[@]}" -gt 0 ]; then
+            # Get list of players who have joined
+            mapfile -t players_who_joined_list < <( comm -13 \
+                <(printf '%s\n' "${old_player_list[@]}") \
+                <(printf '%s\n' "${current_player_list[@]}") )
+        fi
 
-            # Searching players who have joined
-            for new_player in "${new_player_list[@]}"; do
-                new_player_steamid=$(get_steamid "${new_player}")
-                # If in new player list then they joined
-                if [ "$new_player_steamid" = "$player_steamid" ]; then
-                    player_name=$( get_playername "${player}" )
-                    LogInfo "${player_name} has joined"
-                    broadcast_command "${player_name} has joined"
-                    continue 2
-                fi
-            done
+        # If there are old players then some may have left
+        if [ "${#old_player_list[@]}" -gt 0 ]; then
+            # Get list of players who have left
+            mapfile -t players_who_left_list < <( comm -23 \
+                <(printf '%s\n' "${old_player_list[@]}") \
+                <(printf '%s\n' "${current_player_list[@]}") )
+        fi
 
-            # Searching players who have left
-            for old_player in "${old_player_list[@]}"; do
-                old_player_steamid=$(get_steamid "${old_player}")
-                # If in old player list then they left
-                if [ "$old_player_steamid" = "$player_steamid" ]; then
-                    player_name=$( get_playername "${player}" )
-                    LogInfo "${player_name} has left"
-                    broadcast_command "${player_name} has left"
-                    continue 2
-                fi
-            done
+        # Log all players who have left
+        for player in "${players_who_left_list[@]}"; do
+            player_name=$( get_playername "${player}" )
+            LogInfo "${player_name} has left"
+            broadcast_command "${player_name} has left"
         done
-        old_player_list=("${new_player_list[@]}")
+
+        # Log all players who have joined
+        for player in "${players_who_joined_list[@]}"; do
+            player_name=$( get_playername "${player}" )
+            LogInfo "${player_name} has joined"
+            broadcast_command "${player_name} has joined"
+        done
+
+        old_player_list=("${current_player_list[@]}")
+        players_who_left_list=( )
+        players_who_joined_list=( )
     fi
     sleep "${PLAYER_LOGGING_POLL_PERIOD}"
 done

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -143,7 +143,7 @@ default:
   password: "${ADMIN_PASSWORD}"
 EOL
 
-if [ "${ENABLE_PLAYER_LOGGING,,}" = true ] && [[ "${PLAYER_LOGGING_POLL_PERIOD}" =~ ^[0-9]+$ ]]; then
+if [ "${ENABLE_PLAYER_LOGGING,,}" = true ] && [[ "${PLAYER_LOGGING_POLL_PERIOD}" =~ ^[0-9]+$ ]] && [ "${RCON_ENABLED,,}" = true ]; then
     if [[ "$(id -u)" -eq 0 ]]; then
         su steam -c /home/steam/server/player_logging.sh &
     else


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Modify player logging to make more readable

## Choices

* Switching to comm so we can see who have left or join instead of iterating to determine their change 

## Test instructions

1. Start a server
2. Verify it logs it you leaving and joining in docker
3. With players in game test with others joining
4. Test multiple players joining within the same polling period
5. Delete player data, create a new players with any name that may break it (Spaces, commas, numbers, etc)

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
