### PR TITLE
Remove temp file on failure in update required

### DIFF
--- a/scripts/helper_install.sh
+++ b/scripts/helper_install.sh
@@ -65,6 +65,7 @@ UpdateRequired() {
   if [ "$http_code" -ne 200 ]; then
       LogError "There was a problem reaching the Steam api. Unable to check for updates!"
       DiscordMessage "There was a problem reaching the Steam api. Unable to check for updates!" "failure"
+      rm "$temp_file"
       return 2
   fi
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Currently when the server check for updates it create a temporary file however the file is not deleted if there is an issue retrieving the manifest id.

## Choices

* Removing file on failure

## Test instructions

1. Create server
2. bash into the server and change the URL on line 63 in helper_install.sh to an invalid one
3. list files in `ls /tmp`
4. Run update
5. Verify there is no tmp file in `ls /tmp`

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
