### PR TITLE
Switch to pidof in restore

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -72,7 +72,7 @@ if [ -f "$BACKUP_FILE" ]; then
         server_pid=$(pidof PalServer-Linux-Test)
         if [ -n "${server_pid}" ]; then
             LogInfo "Waiting for Palworld to exit.."
-            tail --pid="${server_pid}" -f 2>/dev/null
+            tail --pid="${server_pid}" -f /dev/null
         fi
           LogSuccess "Shutdown Complete"
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -74,7 +74,7 @@ if [ -f "$BACKUP_FILE" ]; then
             LogInfo "Waiting for Palworld to exit.."
             tail --pid="${server_pid}" -f /dev/null
         fi
-          LogSuccess "Shutdown Complete"
+        LogSuccess "Shutdown Complete"
 
         trap - ERR
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -69,12 +69,10 @@ if [ -f "$BACKUP_FILE" ]; then
             exit 1
         fi
 
-        mapfile -t server_pids < <(pgrep PalServer-Linux-Test)
-        if [ "${#server_pids[@]}" -ne 0 ]; then
+        server_pid=$(pidof PalServer-Linux-Test)
+        if [ -n "${server_pid}" ]; then
             LogInfo "Waiting for Palworld to exit.."
-            for pid in "${server_pids[@]}"; do
-                tail --pid="$pid" -f 2>/dev/null
-            done
+            tail --pid="${server_pid}" -f 2>/dev/null
         fi
           LogSuccess "Shutdown Complete"
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Resolves #437 
* Remove extra loop in restore

## Choices

* Switching to pidof since we use pidof in start.sh

## Test instructions

1. Verify restore still works

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
