### PR TITLE
Fix RCON errors during startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gettext-base=0.21-12 \
     xdg-user-dirs=0.18-1 \
     jo=1.9-1 \
+    netcat-traditional=1.10-47 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/player_logging.sh
+++ b/scripts/player_logging.sh
@@ -12,6 +12,12 @@ get_playername(){
     echo "${player_info}" | sed -E 's/,([0-9]+),[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]//g'
 }
 
+# Wait until rcon port is open
+while ! nc -z 127.0.0.1 "${RCON_PORT}"; do
+    sleep 5
+    LogInfo "Waiting for RCON port to open to show player logging..."
+done
+
 while true; do
     server_pid=$(pidof PalServer-Linux-Test)
     if [ -n "${server_pid}" ]; then


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

Fix `cli: execute: auth: rcon: dial tcp 127.0.0.1:25575: connect: connection refused` during startup

## Choices

Poll the rcon port with netcat untill the rcon port is open and listening, after that start the player polling

## Test instructions

Start the server, check if the `cli: execute: auth: rcon: dial tcp 127.0.0.1:25575: connect: connection refused` error stops showing but instead displaying: `Waiting for RCON port to open to show player logging...`

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
