### PR TITLE
Check RCON enabled before detecting port

### DIFF
--- a/scripts/player_logging.sh
+++ b/scripts/player_logging.sh
@@ -13,10 +13,12 @@ get_playername(){
 }
 
 # Wait until rcon port is open
-while ! nc -z 127.0.0.1 "${RCON_PORT}"; do
-    sleep 5
-    LogInfo "Waiting for RCON port to open to show player logging..."
-done
+if [ "${RCON_ENABLED}" = true ]; then
+    while ! nc -z 127.0.0.1 "${RCON_PORT}"; do
+        sleep 5
+        LogInfo "Waiting for RCON port to open to show player logging..."
+    done
+fi
 
 while true; do
     server_pid=$(pidof PalServer-Linux-Test)


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

Before detecting that the RCON port is available, we should check if RCON is selected to be enabled

## Choices

If RCON_ENABLED is configured in the environment variable and RCON_PORT is configured, you need to use nc to check.

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.