### PR TITLE
Generate Engine.ini based on ENV vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,8 @@ ENV HOME=/home/steam \
     DISCORD_PRE_SHUTDOWN_MESSAGE="Server is shutting down..." \
     DISCORD_POST_SHUTDOWN_MESSAGE="Server has been stopped!" \
     ENABLE_PLAYER_LOGGING=true \
-    PLAYER_LOGGING_POLL_PERIOD=5
+    PLAYER_LOGGING_POLL_PERIOD=5 \
+    DISABLE_GENERATE_ENGINE=true
 
 COPY ./scripts /home/steam/server/
 

--- a/docusaurus/docs/getting-started/configuration/engine-settings.md
+++ b/docusaurus/docs/getting-started/configuration/engine-settings.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 3
+---
+
+# Engine Settings
+
+Changing Engine Settings with Environment variables.
+
+## With Environment Variables
+
+:::warning
+These Environment Variables and Settings are subject to change since the game is still in beta.
+:::
+
+Converting engine settings to environment variables follow the same principles (with some exceptions):
+
+* all capital letters
+* split words by inserting an underscore
+* remove the single letter if the setting starts with one (like 'b')
+
+For example:
+
+* LanServerMaxTickRate -> LAN_SERVER_MAX_TICK_RATE
+* bUseFixedFrameRate -> USE_FIXED_FRAME_RATE
+* NetClientTicksPerSecond -> NET_CLIENT_TICKS_PER_SECOND
+
+| Variable                      | Description                                                                                                     | Default Value | Allowed Value      |
+|-------------------------------|-----------------------------------------------------------------------------------------------------------------|---------------|--------------------|
+| LAN_SERVER_MAX_TICK_RATE      | Sets maximum ticks per second for LAN servers, higher rates result in smoother gameplay.                        | 120           | Integer            |
+| NET_SERVER_MAX_TICK_RATE      | Sets maximum ticks per second for Internet servers, similarly ensuring smoother online gameplay.                | 120           | Integer            |
+| CONFIGURED_INTERNET_SPEED     | Sets the assumed player internet speed in bytes per second. High value reduces chances of bandwidth throttling. | 104857600     | Integer (in bytes) |
+| CONFIGURED_LAN_SPEED          | Sets the LAN speed, ensuring LAN players can utilize maximum network capacity.                                  | 104857600     | Integer (in bytes) |
+| MAX_CLIENT_RATE               | Maximum data transfer rate per client for all connections, set to a high value to prevent data capping.         | 104857600     | Integer (in bytes) |
+| MAX_INTERNET_CLIENT_RATE      | Specifically targets internet clients, allowing for high-volume data transfer without restrictions.             | 104857600     | Integer (in bytes) |
+| SMOOTH_FRAME_RATE             | Enables the game engine to smooth out frame rate fluctuations for a more consistent visual experience.          | true          | Boolean            |
+| SMOOTH_FRAME_RATE_UPPER_LIMIT | Sets a max target frame rate range for smoothing.                                                               | 120.000000    | Float              |
+| SMOOTH_FRAME_RATE_LOWER_LIMIT | Sets a min target frame rate range for smoothing.                                                               | 30.000000     | Float              |
+| USE_FIXED_FRAME_RATE          | Enables the use of a fixed frame rate                                                                           | false         | Boolean            |
+| FIXED_FRAME_RATE              | Fixed frame rate                                                                                                | 120.000000    | Float              |
+| MIN_DESIRED_FRAME_RATE        | Specifies a minimum acceptable frame rate, ensuring the game runs smoothly at least at this frame rate.         | 60.000000     | Float              |
+| NET_CLIENT_TICKS_PER_SECOND   | Increases the update frequency for clients, enhancing responsiveness and reducing lag.                          | 120           | Integer            |
+
+:::tip
+While setting the server tickrate above to 120 fps will make some gameplay aspect smother,
+it won't fix rubber-banding and will tax your hardware significantly more.
+:::

--- a/docusaurus/docs/getting-started/configuration/server-commands.md
+++ b/docusaurus/docs/getting-started/configuration/server-commands.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Server Commands (RCON)

--- a/scripts/compile-engine.sh
+++ b/scripts/compile-engine.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# shellcheck source=scripts/helper_functions.sh
+source "/home/steam/server/helper_functions.sh"
+
+engine_file="/palworld/Pal/Saved/Config/LinuxServer/Engine.ini"
+engine_dir=$(dirname "$engine_file")
+
+mkdir -p "$engine_dir" || exit
+# If file exists then check if it is writable
+if [ -f "$engine_file" ]; then
+    if ! isWritable "$engine_file"; then
+        LogError "Unable to create $engine_file"
+        exit 1
+    fi
+# If file does not exist then check if the directory is writable
+elif ! isWritable "$engine_dir"; then
+    # Exiting since the file does not exist and the directory is not writable.
+    LogError "Unable to create $engine_file"
+    exit 1
+fi
+
+LogAction "Compiling Engine.ini"
+
+export LAN_SERVER_MAX_TICK_RATE=${LAN_SERVER_MAX_TICK_RATE:-120}
+export NET_SERVER_MAX_TICK_RATE=${NET_SERVER_MAX_TICK_RATE:-120}
+export CONFIGURED_INTERNET_SPEED=${CONFIGURED_INTERNET_SPEED:-104857600}
+export CONFIGURED_LAN_SPEED=${CONFIGURED_LAN_SPEED:-104857600}
+export MAX_CLIENT_RATE=${MAX_CLIENT_RATE:-104857600}
+export MAX_INTERNET_CLIENT_RATE=${MAX_INTERNET_CLIENT_RATE:-104857600}
+export SMOOTH_FRAME_RATE=${SMOOTH_FRAME_RATE:-true}
+export SMOOTH_FRAME_RATE_UPPER_LIMIT=${SMOOTH_FRAME_RATE_UPPER_LIMIT:-120.000000}
+export SMOOTH_FRAME_RATE_LOWER_LIMIT=${SMOOTH_FRAME_RATE_LOWER_LIMIT:-30.000000}
+export USE_FIXED_FRAME_RATE=${USE_FIXED_FRAME_RATE:-false}
+export FIXED_FRAME_RATE=${FIXED_FRAME_RATE:-120}
+export MIN_DESIRED_FRAME_RATE=${MIN_DESIRED_FRAME_RATE:-60}
+export NET_CLIENT_TICKS_PER_SECOND=${NET_CLIENT_TICKS_PER_SECOND:-120}
+
+if [ "${DEBUG,,}" = true ]; then
+cat <<EOF
+====Debug====
+LAN_SERVER_MAX_TICK_RATE=$LAN_SERVER_MAX_TICK_RATE
+NET_SERVER_MAX_TICK_RATE=$NET_SERVER_MAX_TICK_RATE
+CONFIGURED_INTERNET_SPEED=$CONFIGURED_INTERNET_SPEED
+CONFIGURED_LAN_SPEED=$CONFIGURED_LAN_SPEED
+MAX_CLIENT_RATE=$MAX_CLIENT_RATE
+MAX_INTERNET_CLIENT_RATE=$MAX_INTERNET_CLIENT_RATE
+SMOOTH_FRAME_RATE=$SMOOTH_FRAME_RATE
+USE_FIXED_FRAME_RATE=$USE_FIXED_FRAME_RATE
+FIXED_FRAME_RATE=$FIXED_FRAME_RATE
+MIN_DESIRED_FRAME_RATE=$MIN_DESIRED_FRAME_RATE
+NET_CLIENT_TICKS_PER_SECOND=$NET_CLIENT_TICKS_PER_SECOND
+====Debug====
+EOF
+fi
+
+cat > "$engine_file" <<EOF
+$(envsubst < /home/steam/server/files/Engine.ini.template)
+EOF
+
+LogSuccess "Compiling Engine.ini done!"

--- a/scripts/files/Engine.ini.template
+++ b/scripts/files/Engine.ini.template
@@ -1,0 +1,95 @@
+[Core.System]
+Paths=../../../Engine/Content
+Paths=%GAMEDIR%Content
+Paths=../../../Engine/Plugins/2D/Paper2D/Content
+Paths=../../../Engine/Plugins/Animation/ControlRigSpline/Content
+Paths=../../../Engine/Plugins/Animation/ControlRig/Content
+Paths=../../../Engine/Plugins/Animation/IKRig/Content
+Paths=../../../Engine/Plugins/Animation/MotionWarping/Content
+Paths=../../../Engine/Plugins/Bridge/Content
+Paths=../../../Engine/Plugins/Compositing/Composure/Content
+Paths=../../../Engine/Plugins/Compositing/OpenColorIO/Content
+Paths=../../../Engine/Plugins/Developer/AnimationSharing/Content
+Paths=../../../Engine/Plugins/Developer/Concert/ConcertSync/ConcertSyncClient/Content
+Paths=../../../Engine/Plugins/Editor/BlueprintHeaderView/Content
+Paths=../../../Engine/Plugins/Editor/GeometryMode/Content
+Paths=../../../Engine/Plugins/Editor/ModelingToolsEditorMode/Content
+Paths=../../../Engine/Plugins/Editor/ObjectMixer/LightMixer/Content
+Paths=../../../Engine/Plugins/Editor/ObjectMixer/ObjectMixer/Content
+Paths=../../../Engine/Plugins/Editor/SpeedTreeImporter/Content
+Paths=../../../Engine/Plugins/Enterprise/DatasmithContent/Content
+Paths=../../../Engine/Plugins/Enterprise/GLTFExporter/Content
+Paths=../../../Engine/Plugins/Experimental/ChaosCaching/Content
+Paths=../../../Engine/Plugins/Experimental/ChaosClothEditor/Content
+Paths=../../../Engine/Plugins/Experimental/ChaosNiagara/Content
+Paths=../../../Engine/Plugins/Experimental/ChaosSolverPlugin/Content
+Paths=../../../Engine/Plugins/Experimental/CommonUI/Content
+Paths=../../../Engine/Plugins/Experimental/Dataflow/Content
+Paths=../../../Engine/Plugins/Experimental/FullBodyIK/Content
+Paths=../../../Engine/Plugins/Experimental/GeometryCollectionPlugin/Content
+Paths=../../../Engine/Plugins/Experimental/GeometryFlow/Content
+Paths=../../../Engine/Plugins/Experimental/ImpostorBaker/Content
+Paths=../../../Engine/Plugins/Experimental/Landmass/Content
+Paths=../../../Engine/Plugins/Experimental/MeshLODToolset/Content
+Paths=../../../Engine/Plugins/Experimental/PythonScriptPlugin/Content
+Paths=../../../Engine/Plugins/Experimental/StaticMeshEditorModeling/Content
+Paths=../../../Engine/Plugins/Experimental/UVEditor/Content
+Paths=../../../Engine/Plugins/Experimental/Volumetrics/Content
+Paths=../../../Engine/Plugins/Experimental/Water/Content
+Paths=../../../Engine/Plugins/FX/Niagara/Content
+Paths=../../../Engine/Plugins/JsonBlueprintUtilities/Content
+Paths=../../../Engine/Plugins/Media/MediaCompositing/Content
+Paths=../../../Engine/Plugins/Media/MediaPlate/Content
+Paths=../../../Engine/Plugins/MovieScene/SequencerScripting/Content
+Paths=../../../Engine/Plugins/PivotTool/Content
+Paths=../../../Engine/Plugins/PlacementTools/Content
+Paths=../../../Engine/Plugins/Runtime/AudioSynesthesia/Content
+Paths=../../../Engine/Plugins/Runtime/AudioWidgets/Content
+Paths=../../../Engine/Plugins/Runtime/GeometryProcessing/Content
+Paths=../../../Engine/Plugins/Runtime/Metasound/Content
+Paths=../../../Engine/Plugins/Runtime/ResonanceAudio/Content
+Paths=../../../Engine/Plugins/Runtime/SunPosition/Content
+Paths=../../../Engine/Plugins/Runtime/Synthesis/Content
+Paths=../../../Engine/Plugins/Runtime/WaveTable/Content
+Paths=../../../Engine/Plugins/Runtime/WebBrowserWidget/Content
+Paths=../../../Engine/Plugins/SkyCreatorPlugin/Content
+Paths=../../../Engine/Plugins/VirtualProduction/CameraCalibrationCore/Content
+Paths=../../../Engine/Plugins/VirtualProduction/LiveLinkCamera/Content
+Paths=../../../Engine/Plugins/VirtualProduction/Takes/Content
+Paths=../../../Engine/Plugins/Web/HttpBlueprint/Content
+Paths=../../../Pal/Plugins/DLSS/Content
+Paths=../../../Pal/Plugins/EffectsChecker/Content
+Paths=../../../Pal/Plugins/HoudiniEngine/Content
+Paths=../../../Pal/Plugins/PPSkyCreatorPlugin/Content
+Paths=../../../Pal/Plugins/PocketpairUser/Content
+Paths=../../../Pal/Plugins/SpreadSheetToCsv/Content
+Paths=../../../Pal/Plugins/Wwise/Content
+
+; Online Subsystem Utils Configuration
+; Adjusting tick rates for LAN and Internet servers to enhance the frequency of game state updates, 
+; leading to smoother gameplay and less desynchronization between server and clients.
+[/script/onlinesubsystemutils.ipnetdriver]
+LanServerMaxTickRate=$LAN_SERVER_MAX_TICK_RATE
+NetServerMaxTickRate=$NET_SERVER_MAX_TICK_RATE
+
+; Player Configuration
+; These settings are crucial for optimizing the network bandwidth allocation per player, 
+; allowing for more data to be sent and received without bottlenecking.
+[/script/engine.player]
+ConfiguredInternetSpeed=$CONFIGURED_INTERNET_SPEED
+ConfiguredLanSpeed=$CONFIGURED_LAN_SPEED
+
+[/script/socketsubsystemepic.epicnetdriver]
+MaxClientRate=$MAX_CLIENT_RATE
+MaxInternetClientRate=$MAX_INTERNET_CLIENT_RATE
+
+; Engine Configuration
+; These settings manage how the game's frame rate is handled, which can impact how smoothly the game runs.
+; Smoother frame rates can lead to a better synchronization between client and server.
+[/script/engine.engine]
+bSmoothFrameRate=$SMOOTH_FRAME_RATE
+SmoothedFrameRateRange=(LowerBound=(Type=Inclusive,Value=$SMOOTH_FRAME_RATE_LOWER_LIMIT),UpperBound=(Type=Exclusive,Value=$SMOOTH_FRAME_RATE_UPPER_LIMIT))
+bUseFixedFrameRate=$USE_FIXED_FRAME_RATE
+FixedFrameRate=$FIXED_FRAME_RATE
+MinDesiredFrameRate=$MIN_DESIRED_FRAME_RATE
+NetClientTicksPerSecond=$NET_CLIENT_TICKS_PER_SECOND

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -105,6 +105,9 @@ else
   /home/steam/server/compile-settings.sh || exit
 fi
 
+if [ "${DISABLE_GENERATE_ENGINE,,}" = false ]; then
+    /home/steam/server/compile-engine.sh || exit
+fi
 LogAction "GENERATING CRONTAB"
 truncate -s 0  "/home/steam/server/crontab"
 if [ "${BACKUP_ENABLED,,}" = true ]; then


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
Fixes https://github.com/thijsvanloef/palworld-server-docker/issues/257 https://github.com/thijsvanloef/palworld-server-docker/issues/176
Enable users to generate the Engine.ini using evironment variabels

## Choices

Using the same method as compile-settings.sh, compile the engine settings.

## Test instructions

1. Build the container
2. set `DISABLE_GENERATE_ENGINE` to `false`
3. check that `./palworld/Pal/Saved/Config/LinuxServer/engine.ini` has been updated

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the docusaurus.
* [x] I've not introduced breaking changes.
