### PR TITLE
update "EpicApp=Palserver" to "-publiclobby" per 1.5.0 changes

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -82,7 +82,7 @@ if [ "${MULTITHREADING,,}" = true ]; then
 fi
 
 if [ "${RCON_ENABLED,,}" = true ]; then
-    STARTCOMMAND+=("-rcon)
+    STARTCOMMAND+=("-rcon")
 fi
 
 if [ "${DISABLE_GENERATE_SETTINGS,,}" = true ]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -81,7 +81,7 @@ if [ "${MULTITHREADING,,}" = true ]; then
     STARTCOMMAND+=("-useperfthreads" "-NoAsyncLoadingThread" "-UseMultithreadForDS")
 fi
 
-if [ "${RCON_ENABLED,,}" = true ] && [ -n "${RCON_PORT}"]; then
+if [ "${RCON_ENABLED,,}" = true ] && [ -n "${RCON_PORT}" ]; then
     STARTCOMMAND+=("-rconport=${RCON_PORT}")
 fi
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -74,7 +74,7 @@ if [ -n "${QUERY_PORT}" ]; then
 fi
 
 if [ "${COMMUNITY,,}" = true ]; then
-    STARTCOMMAND+=("EpicApp=PalServer")
+    STARTCOMMAND+=("-publiclobby")
 fi
 
 if [ "${MULTITHREADING,,}" = true ]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -81,7 +81,7 @@ if [ "${MULTITHREADING,,}" = true ]; then
     STARTCOMMAND+=("-useperfthreads" "-NoAsyncLoadingThread" "-UseMultithreadForDS")
 fi
 
-if [ "${RCON_ENABLED,,}" = true ]; then
+if [ "${RCON_ENABLED,,}" = true ] && [ -n "${RCON_PORT}"]; then
     STARTCOMMAND+=("-rconport=${RCON_PORT}")
 fi
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -81,8 +81,8 @@ if [ "${MULTITHREADING,,}" = true ]; then
     STARTCOMMAND+=("-useperfthreads" "-NoAsyncLoadingThread" "-UseMultithreadForDS")
 fi
 
-if [ "${RCON_ENABLED,,}" = true ] && [ -n "${RCON_PORT}" ]; then
-    STARTCOMMAND+=("-rconport=${RCON_PORT}")
+if [ "${RCON_ENABLED,,}" = true ]; then
+    STARTCOMMAND+=("-rcon)
 fi
 
 if [ "${DISABLE_GENERATE_SETTINGS,,}" = true ]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -81,6 +81,10 @@ if [ "${MULTITHREADING,,}" = true ]; then
     STARTCOMMAND+=("-useperfthreads" "-NoAsyncLoadingThread" "-UseMultithreadForDS")
 fi
 
+if [ "${RCON_ENABLED,,}" = true ]; then
+    STARTCOMMAND+=("-rconport=${RCON_PORT}")
+fi
+
 if [ "${DISABLE_GENERATE_SETTINGS,,}" = true ]; then
   LogAction "GENERATING CONFIG"
   LogWarn "Env vars will not be applied due to DISABLE_GENERATE_SETTINGS being set to TRUE!"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

Changes were made in 1.5.0 to server start args (lol why pocketpair?)
See https://tech.palworldgame.com/settings-and-operation/arguments/ for documentation
This PR updates the "EpicApp=PalServer" arg to the current "publiclobby" arg to relist community servers

## Choices

Because Pocket Pair made us change it.

## Test instructions

No testing needed, simple arg change per official documentation.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
