### PR TITLE
Fix link to rcon commands list

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ This will open a CLI that uses RCON to write commands to the Palworld Server.
 | Info                             | Show server information.                            |
 | Save                             | Save the world data.                                |
 
-For a full list of commands go to: [https://tech.palworldgame.com/server-commands](https://tech.palworldgame.com/server-commands)
+For a full list of commands go to: [https://tech.palworldgame.com/settings-and-operation/commands](https://tech.palworldgame.com/settings-and-operation/commands)
 
 ## Creating a backup
 

--- a/docs/kr/README.md
+++ b/docs/kr/README.md
@@ -284,7 +284,7 @@ docker exec -it palworld-server rcon-cli "Broadcast Hello everyone"
 | Info                             | 서버 정보를 표시합니다.                            |
 | Save                             | 월드 정보를 저장합니다.                            |
 
-전체 명령어 목록을 보려면 다음으로 이동하세요: [https://tech.palworldgame.com/server-commands](https://tech.palworldgame.com/server-commands)
+전체 명령어 목록을 보려면 다음으로 이동하세요: [https://tech.palworldgame.com/settings-and-operation/commands](https://tech.palworldgame.com/settings-and-operation/commands)
 
 ## 백업 만들기
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -238,7 +238,7 @@ docker exec -it palworld-server rcon-cli
 | Info                       | 显示服务器信息。       |
 | Save                       | 保存游戏。          |
 
-请查看 [官方文档](https://tech.palworldgame.com/server-commands) 以获取所有命令。
+请查看 [官方文档](https://tech.palworldgame.com/settings-and-operation/commands) 以获取所有命令。
 
 ## 创建备份
 

--- a/docusaurus/docs/getting-started/configuration/server-commands.md
+++ b/docusaurus/docs/getting-started/configuration/server-commands.md
@@ -38,4 +38,4 @@ This will open a CLI that uses RCON to write commands to the Palworld Server.
 | Info                             | Show server information.                            |
 | Save                             | Save the world data.                                |
 
-For a full list of commands go to: [https://tech.palworldgame.com/server-commands](https://tech.palworldgame.com/server-commands)
+For a full list of commands go to: [https://tech.palworldgame.com/settings-and-operation/commands](https://tech.palworldgame.com/settings-and-operation/commands)

--- a/docusaurus/i18n/de/docusaurus-plugin-content-docs/current/getting-started/configuration/server-commands.md
+++ b/docusaurus/i18n/de/docusaurus-plugin-content-docs/current/getting-started/configuration/server-commands.md
@@ -38,4 +38,4 @@ Dies öffnet eine CLI, die RCON verwendet, um Befehle an den Palworld-Server zu 
 | Info                            | Zeigt Serverinformationen an.                                   |
 | Save                            | Speichern Sie die Weltendaten.                                  |
 
-Für eine vollständige Liste der Befehle gehen Sie zu: [https://tech.palworldgame.com/server-commands](https://tech.palworldgame.com/server-commands)
+Für eine vollständige Liste der Befehle gehen Sie zu: [https://tech.palworldgame.com/settings-and-operation/commands](https://tech.palworldgame.com/settings-and-operation/commands)

--- a/docusaurus/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/configuration/server-commands.md
+++ b/docusaurus/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/configuration/server-commands.md
@@ -37,4 +37,4 @@ docker exec -it palworld-server rcon-cli "Broadcast Hello everyone"
 | Info                             | 서버 정보를 표시합니다.                            |
 | Save                             | 월드 정보를 저장합니다.                            |
 
-전체 명령어 목록을 보려면 다음으로 이동하세요: [https://tech.palworldgame.com/server-commands](https://tech.palworldgame.com/server-commands)
+전체 명령어 목록을 보려면 다음으로 이동하세요: [https://tech.palworldgame.com/settings-and-operation/commands](https://tech.palworldgame.com/settings-and-operation/commands)

--- a/docusaurus/i18n/nl/docusaurus-plugin-content-docs/current/getting-started/configuration/server-commands.md
+++ b/docusaurus/i18n/nl/docusaurus-plugin-content-docs/current/getting-started/configuration/server-commands.md
@@ -38,4 +38,4 @@ Dit opent een CLI die RCON gebruikt om opdrachten naar de Palworld Server te sch
 | Info                             | Toon serverinformatie.                            |
 | Save                             | Sla de wereldgegevens op.                                |
 
-Voor een volledige lijst met opdrachten ga naar: [https://tech.palworldgame.com/server-commands](https://tech.palworldgame.com/server-commands)
+Voor een volledige lijst met opdrachten ga naar: [https://tech.palworldgame.com/settings-and-operation/commands](https://tech.palworldgame.com/settings-and-operation/commands)

--- a/docusaurus/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/configuration/server-commands.md
+++ b/docusaurus/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/configuration/server-commands.md
@@ -42,4 +42,4 @@ docker exec -it palworld-server rcon-cli "Broadcast Hello everyone"
 | Info                       | 显示服务器信息。       |
 | Save                       | 保存游戏。          |
 
-请查看 [官方文档](https://tech.palworldgame.com/server-commands) 以获取所有命令。
+请查看 [官方文档](https://tech.palworldgame.com/settings-and-operation/commands) 以获取所有命令。


### PR DESCRIPTION
Old link redirected to a 404 page

## Context <!-- markdownlint-disable MD041 -->

Fix error in readme

## Choices

....

## Test instructions

Nothing to test

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.
