### PR TITLE
fix bug that displays start when server has been stopped

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -182,5 +182,5 @@ DiscordMessage "Start" "${DISCORD_PRE_START_MESSAGE}" "success"
 echo "${STARTCOMMAND[*]}"
 "${STARTCOMMAND[@]}"
 
-DiscordMessage "Start" "${DISCORD_POST_SHUTDOWN_MESSAGE}" "failure"
+DiscordMessage "Stop" "${DISCORD_POST_SHUTDOWN_MESSAGE}" "failure"
 exit 0


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
Fix 485

The server stop messages was titled: "Start". Now correctly titled: "Stop"

## Choices

* <!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.
