### PR TITLE
Fix Discord old backup remove message to include old_backup_days

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -33,11 +33,11 @@ fi
 if [[ "${OLD_BACKUP_DAYS}" =~ ^[0-9]+$ ]]; then
     LogAction "Removing Old Backups"
     LogInfo "Removing backups older than ${OLD_BACKUP_DAYS} days"
-    DiscordMessage "Backup" "${DISCORD_PRE_BACKUP_DELETE_MESSAGE//file_path/${FILE_PATH}}" "in-progress" "${DISCORD_PRE_BACKUP_DELETE_MESSAGE_ENABLED}" "${DISCORD_PRE_BACKUP_DELETE_MESSAGE_URL}"
+    DiscordMessage "Backup" "${DISCORD_PRE_BACKUP_DELETE_MESSAGE//old_backup_days/${OLD_BACKUP_DAYS}}" "in-progress" "${DISCORD_PRE_BACKUP_DELETE_MESSAGE_ENABLED}" "${DISCORD_PRE_BACKUP_DELETE_MESSAGE_URL}"
     find /palworld/backups/ -mindepth 1 -maxdepth 1 -mtime "+${OLD_BACKUP_DAYS}" -type f -name 'palworld-save-*.tar.gz' -print -delete
-    DiscordMessage "Backup" "${DISCORD_POST_BACKUP_DELETE_MESSAGE//file_path/${FILE_PATH}}" "success" "${DISCORD_POST_BACKUP_DELETE_MESSAGE_ENABLED}" "${DISCORD_POST_BACKUP_DELETE_MESSAGE_URL}"
+    DiscordMessage "Backup" "${DISCORD_POST_BACKUP_DELETE_MESSAGE//old_backup_days/${OLD_BACKUP_DAYS}}" "success" "${DISCORD_POST_BACKUP_DELETE_MESSAGE_ENABLED}" "${DISCORD_POST_BACKUP_DELETE_MESSAGE_URL}"
     exit 0
 fi
 
 LogError "Unable to delete old backups, OLD_BACKUP_DAYS is not an integer. OLD_BACKUP_DAYS=${OLD_BACKUP_DAYS}"
-DiscordMessage "Backup" "${DISCORD_ERR_BACKUP_DELETE_MESSAGE//old_backup_days/${OLD_BACKUP_DAYS}}}" "failure" "${DISCORD_ERR_BACKUP_DELETE_MESSAGE_ENABLED}" "${DISCORD_ERR_BACKUP_DELETE_MESSAGE_URL}"
+DiscordMessage "Backup" "${DISCORD_ERR_BACKUP_DELETE_MESSAGE//old_backup_days/${OLD_BACKUP_DAYS}}" "failure" "${DISCORD_ERR_BACKUP_DELETE_MESSAGE_ENABLED}" "${DISCORD_ERR_BACKUP_DELETE_MESSAGE_URL}"


### PR DESCRIPTION
Fix Discord old backup remove message to include old_backup_days.

## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

<!-- What do you want to achieve with this PR? -->
Issue #501 that I drafted was modified by #502.
The message is now sent, but old_backup_days is broken.
So I fixed it.

## Choices

<!-- * Why did you solve it like this? -->
To apply old_backup_message (e.g. 30).

## Test instructions

1. I built my own image with the code changes and ran the `backup` command on it to see the messages sent to Discord.

Before fix
![スクリーンショット 2024-03-11 094329](https://github.com/thijsvanloef/palworld-server-docker/assets/38070267/19bb5cab-ab30-49ce-95c1-2bfc1dc8d1f5)

After fix
![スクリーンショット 2024-03-11 094402](https://github.com/thijsvanloef/palworld-server-docker/assets/38070267/f9b7e510-d9cf-4d64-8529-344579a3a006)

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
