### PR TITLE
Excluding game backup folder in our backup.

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -12,7 +12,7 @@ FILE_PATH="/palworld/backups/palworld-save-${DATE}.tar.gz"
 cd /palworld/Pal/ || exit
 
 LogAction "Creating backup"
-tar -zcf "$FILE_PATH" "Saved/"
+tar -zcf "$FILE_PATH" --exclude "backup" "Saved/"
 
 if [ "$(id -u)" -eq 0 ]; then
     chown steam:steam "$FILE_PATH"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

<!-- What do you want to achieve with this PR? -->
This change means backup will no longer copy the games backup #520 

## Choices

Simply using `--exclude backup` to exclude the backup folder as there are no other files or folders named backup in the Saved directory.

## Alternative Choice

I had considered using find to so reduce the possibility of excluding the wrong files/directories if any were named backup however decided against this would be addressing an issue that the user must create.

## Test instructions

1. Ideal up the game using the latest image
2. Backup again using the this PR
3. Verify this PR backup has no backup directory inside of it.

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
