### PR TITLE
update backup.sh, Do not package the official backup directory together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ palworld
 values*.yaml
 .env
 .vscode
+/person_files/

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -12,7 +12,7 @@ FILE_PATH="/palworld/backups/palworld-save-${DATE}.tar.gz"
 cd /palworld/Pal/ || exit
 
 LogAction "Creating backup"
-tar -zcf "$FILE_PATH" "Saved/"
+tar -zcf "$FILE_PATH" --exclude="SaveGames/*/*/backup" "Saved/"
 
 if [ "$(id -u)" -eq 0 ]; then
     chown steam:steam "$FILE_PATH"


### PR DESCRIPTION
Do not package the official backup directory together

## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

<!-- What do you want to achieve with this PR? -->

## Choices

<!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

- [ ] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [ ] I've not introduced breaking changes.
- [ ] My changes do not violate linting rules.
