### PR TITLE
The ShowPlayers and Broadcast commands prefer to use the REST API when it is enabled for player logging.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ ENV HOME=/home/steam \
     RCON_ENABLED=true \
     RCON_PORT=25575 \
     QUERY_PORT=27015 \
+    REST_API_PORT=8212 \
     TZ=UTC \
     SERVER_DESCRIPTION= \
     BACKUP_ENABLED=true \

--- a/scripts/player_logging.sh
+++ b/scripts/player_logging.sh
@@ -9,7 +9,7 @@ get_steamid(){
 
 get_playername(){
     local player_info="${1}"
-    echo "${player_info}" | sed -E 's/,([0-9]+),[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]//g'
+    echo "${player_info}" | sed -E 's/,([0-9A-Z]+),[0-9]+//g'
 }
 
 # Prefer REST API
@@ -30,9 +30,9 @@ done
 while true; do
     server_pid=$(pidof PalServer-Linux-Shipping)
     if [ -n "${server_pid}" ]; then
-        # Player IDs are usally 9 or 10 digits however when a player joins for the first time for a given boot their ID is temporary 00000000 (8x zeros) while loading
-        # Player ID is also 00000000 (8x zeros) when in character creation
-        mapfile -t current_player_list < <( get_players_list | tail -n +2 | sed '/,00000000,[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/d' | sort )
+        # Player IDs are usally 9 or 10 digits however when a player joins for the first time for a given boot their ID is temporary 00000000 (8x zeros or 32x zeros) while loading
+        # Player ID is also 00000000 (8x zeros or 32x zeros) when in character creation
+        mapfile -t current_player_list < <( get_players_list | tail -n +2 | sed -E '/,(0{8}|0{32}),[0-9]+/d' | sort )
 
         # If there are current players then some may have joined
         if [ "${#current_player_list[@]}" -gt 0 ]; then

--- a/scripts/player_logging.sh
+++ b/scripts/player_logging.sh
@@ -12,10 +12,19 @@ get_playername(){
     echo "${player_info}" | sed -E 's/,([0-9]+),[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]//g'
 }
 
-# Wait until rcon port is open
-while ! nc -z 127.0.0.1 "${RCON_PORT}"; do
+# Prefer REST API
+if [ "${REST_API_ENABLED,,}" = true ]; then
+    _PORT=${REST_API_PORT}
+    _LABEL="REST API"
+else
+    _PORT=${RCON_PORT}
+    _LABEL="RCON"
+fi
+
+# Wait until rcon/rest-api port is open
+while ! nc -z localhost "${_PORT}"; do
     sleep 5
-    LogInfo "Waiting for RCON port to open to show player logging..."
+    LogInfo "Waiting for ${_LABEL}(${_PORT}) port to open to show player logging..."
 done
 
 while true; do

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -168,7 +168,7 @@ default:
   password: "${ADMIN_PASSWORD}"
 EOL
 
-if [ "${ENABLE_PLAYER_LOGGING,,}" = true ] && [[ "${PLAYER_LOGGING_POLL_PERIOD}" =~ ^[0-9]+$ ]] && [ "${RCON_ENABLED,,}" = true ]; then
+if [ "${ENABLE_PLAYER_LOGGING,,}" = true ] && [[ "${PLAYER_LOGGING_POLL_PERIOD}" =~ ^[0-9]+$ ]] && ( [ "${REST_API_ENABLED,,}" = true ] || [ "${RCON_ENABLED,,}" = true ] ); then
     if [[ "$(id -u)" -eq 0 ]]; then
         su steam -c /home/steam/server/player_logging.sh &
     else

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -168,7 +168,7 @@ default:
   password: "${ADMIN_PASSWORD}"
 EOL
 
-if [ "${ENABLE_PLAYER_LOGGING,,}" = true ] && [[ "${PLAYER_LOGGING_POLL_PERIOD}" =~ ^[0-9]+$ ]] && ( [ "${REST_API_ENABLED,,}" = true ] || [ "${RCON_ENABLED,,}" = true ] ); then
+if [ "${ENABLE_PLAYER_LOGGING,,}" = true ] && [[ "${PLAYER_LOGGING_POLL_PERIOD}" =~ ^[0-9]+$ ]] && { [ "${REST_API_ENABLED,,}" = true ] || [ "${RCON_ENABLED,,}" = true ] ;} then
     if [[ "$(id -u)" -eq 0 ]]; then
         su steam -c /home/steam/server/player_logging.sh &
     else


### PR DESCRIPTION
RCON cannot handle multibyte strings, so the ShowPlayers and Broadcast commands prefer to use the REST API when it is enabled.

## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

Work around bug with multibyte strings in RCON.

<!-- What do you want to achieve with this PR? -->

The multibyte strings are now displayed correctly.

## Choices

<!-- * Why did you solve it like this? -->
This is because it takes time to fix bugs in RCON.

## Test instructions

1. create docker-compose.override.yml
```yaml
services:
  palworld:
    image: thijsvanloef/palworld-server-docker:debug
    ports:
      - 8212:8212/tcp  # add REST API port
    environment:
      REST_API_ENABLED: true
      REST_API_PORT: 8212
      SERVER_PASSWORD: "" # [override] no password for debug
```
2. build docker image for debug
```shell
docker build -t thijsvanloef/palworld-server-docker:debug .
```
3. run docker container
```shell
docker compose up
```
4. connect from client (PalWorld) and make new character with multibyte string name.
example name:
```
まっする
```
5. show docker logs.
```
[2024-04-19 20:49:37] [LOG] REST accessed endpoint /v1/api/players OK
muscle,3657AB7D000000000000000000000000,76561198847285114 has joined
[2024-04-19 20:49:37] [LOG] まっする joined the server. (User id: steam_76561198847285114)
[2024-04-19 20:49:37] [LOG] REST accessed endpoint /v1/api/announce OK
OK[2024-04-19 20:49:42] [LOG] REST accessed endpoint /v1/api/players OK
muscle,3657AB7D000000000000000000000000,76561198847285114 has left
[2024-04-19 20:49:42] [LOG] REST accessed endpoint /v1/api/announce OK
OKまっする,3657AB7D000000000000000000000000,76561198847285114 has joined
[2024-04-19 20:49:42] [LOG] REST accessed endpoint /v1/api/announce OK
OK[2024-04-19 20:49:47] [LOG] REST accessed endpoint /v1/api/players OK
```

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
