### PR TITLE
Modifying Supercronic Related Code in start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -153,9 +153,8 @@ if [ "${AUTO_REBOOT_ENABLED,,}" = true ] && [ "${RCON_ENABLED,,}" = true ]; then
     supercronic -quiet -test "/home/steam/server/crontab" || exit
 fi
 
-if { [ "${AUTO_UPDATE_ENABLED,,}" = true ] && [ "${UPDATE_ON_BOOT,,}" = true ]; } || [ "${BACKUP_ENABLED,,}" = true ] || \
-    [ "${AUTO_REBOOT_ENABLED,,}" = true ]; then
-    supercronic "/home/steam/server/crontab" &
+if [ -s "/home/steam/server/crontab" ]; then
+    supercronic -passthrough-logs "/home/steam/server/crontab" &
     LogInfo "Cronjobs started"
 else
     LogInfo "No Cronjobs found"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

1. Before registering Supercronic, check the size of the `crontab` file, not variables value.
2. If you perform the task registered in Supercronic, the log as like:
![image](https://github.com/thijsvanloef/palworld-server-docker/assets/105538716/716edf38-1c96-44d1-8682-47bfd50ab9e4)

## Choices

1. If you modify it this way, you don't need to modify it even if related functions are added.
2. Add the `-passthrough-logs` option to Supercronic so that the standard output of the file is displayed normally.
![image](https://github.com/thijsvanloef/palworld-server-docker/assets/105538716/54391b43-3632-423f-9640-c065e1552995)

## Test instructions

1. Set the `BACKUP_ENABLED` variable to `false` so that nothing is stored in the `crontab` file, and check whether the `else` part is executed.
2. Set the `BACKUP_ENABLED` or `AUTO_UPDATE_ENABLED` variable to `true` to see if it goes to the `if` part, and check the log on which `update` was executed.


## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
