### PR TITLE
Updated restore.sh to move Palworld backup folder during restore

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -109,6 +109,19 @@ if [ -f "$BACKUP_FILE" ]; then
             # Decompress the backup file in tmp directory
             tar -zxvf "$BACKUP_FILE" -C "$TMP_PATH"
 
+            # Find backup folders
+            mapfile -t backup_folders < <(find "$RESTORE_PATH" -name "backup" -type d | sed "s|^$RESTORE_PATH||")
+
+            # Check if backup folder parents exist in restore
+            for backup_folder in "${backup_folders[@]}"
+            do
+                backup_folder_dirname=$( dirname "$backup_folder" )
+                if [ -d "$TMP_PATH/$backup_folder_dirname" ]; then
+                    # Move backup folder into restore
+                    mv "$RESTORE_PATH/$backup_folder_dirname/backup" "$TMP_PATH/$backup_folder_dirname"
+                fi
+            done
+
             # Make sure Saves with a different ID are removed before restoring the save
             rm -rf "$RESTORE_PATH/Saved/"
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

<!-- What do you want to achieve with this PR? -->

Implements #521 

## Choices

Only moving default palworld backups if the world exists in our backup/restore

## Test instructions

1. Create a world which has game generated backups
2. Create a backup using our backup tool
3. Restore the backup
4. Verify the palworld backup folder exists in the restore

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
