### PR TITLE
Changed restore order so newest is first

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -42,7 +42,7 @@ fi
 
 # Show up backup list
 LogInfo "Backup List:"
-mapfile -t BACKUP_FILES < <(find "$BACKUP_DIRECTORY_PATH" -type f -name "*.tar.gz" | sort)
+mapfile -t BACKUP_FILES < <(find "$BACKUP_DIRECTORY_PATH" -type f -name "*.tar.gz" | sort -r)
 select BACKUP_FILE in "${BACKUP_FILES[@]}"; do
     if [ -n "$BACKUP_FILE" ]; then
         LogInfo "Selected backup: $BACKUP_FILE"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

<!-- What do you want to achieve with this PR? -->
Implements #622 

## Choices

<!-- * Why did you solve it like this? -->
Doing in order of newest first as I think it's more likely you want to restore a recent backup rather than an older one

## Test instructions

1. Run restore and verify the order is newest to oldest
```
1) /palworld/backups/palworld-save-2024-11-17_07-52-20.tar.gz  4) /palworld/backups/palworld-save-2024-04-04_19-14-04.tar.gz
2) /palworld/backups/palworld-save-2024-04-05_00-00-00.tar.gz  5) /palworld/backups/palworld-save-2024-02-22_08-20-00.tar.gz
3) /palworld/backups/palworld-save-2024-04-04_19-15-20.tar.gz  6) /palworld/backups/palworld-save-2024-02-21_16-26-36.tar.gz
```

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
