### PR TITLE
Fix proxy cert problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,7 +206,7 @@ RUN chmod +x /home/steam/server/autopause/*.sh && \
 # AUTO_PAUSE with Community
 RUN mkdir -p /home/steam/.mitmproxy && \
     openssl genrsa -out ca.key 2048 && \
-    openssl req -x509 -new -nodes -key ca.key -sha256 -out ca.crt -addext keyUsage=critical,keyCertSign -subj "/CN=rootca" && \
+    openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.crt -addext keyUsage=critical,keyCertSign -subj "/CN=rootca" && \
     cat ca.key ca.crt > /home/steam/.mitmproxy/mitmproxy-ca.pem && \
     rm ca.key && \
     mv ca.crt /usr/local/share/ca-certificates/mitmproxy.crt && \

--- a/scripts/autopause/community/init.sh
+++ b/scripts/autopause/community/init.sh
@@ -8,11 +8,14 @@ if isTrue "${COMMUNITY}" && isTrue "${AUTO_PAUSE_ENABLED}" && PlayerLogging_isEn
 
     LogInfo "Launch proxy."
     MITMPROXY_ADDONS_DIR="/home/steam/server/autopause/community/addons"
+    IGNORE_HOSTS="api.steamcmd.net"
+    IGNORE_HOSTS_PATTERN=$(echo "$IGNORE_HOSTS" | tr ',' '\n' | sed 's/\./\\./g' | paste -sd '|' -)
+    MITMPROXY_OPTIONS="--set block_global=false --ssl-insecure --ignore-hosts='^(${IGNORE_HOSTS_PATTERN})\$' -s ${MITMPROXY_ADDONS_DIR}/PalCommCapture.py"
     if isTrue "${AUTO_PAUSE_DEBUG}"; then
-        mitmweb --web-host 0.0.0.0 --set block_global=false --ssl-insecure -s "${MITMPROXY_ADDONS_DIR}/PalCommCapture.py"  &
+        mitmweb --web-host 0.0.0.0 ${MITMPROXY_OPTIONS} &
         LogInfo "Web Interface URL: http://localhost:8081/"
     else
-        mitmdump --set block_global=false --ssl-insecure -s "${MITMPROXY_ADDONS_DIR}/PalCommCapture.py" > /var/log/mitmdump.log &
+        mitmdump ${MITMPROXY_OPTIONS} > /var/log/mitmdump.log &
     fi
 
     echo -n "Wait until proxy is initialized..."
@@ -29,5 +32,5 @@ if isTrue "${COMMUNITY}" && isTrue "${AUTO_PAUSE_ENABLED}" && PlayerLogging_isEn
     LogInfo "Using proxy now."
     export http_proxy="localhost:8080"
     export https_proxy="localhost:8080"
-    export no_proxy="localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+    export no_proxy="localhost,127.0.0.1,::1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8,.local,${IGNORE_HOSTS}"
 fi

--- a/scripts/autopause/services.sh
+++ b/scripts/autopause/services.sh
@@ -35,6 +35,7 @@ AP_stopDaemon() {
 #-------------------------------
 
 AutoPause_init() {
+    AP_isEnabled || return
     APLog "Service ... start"
     AP_clean
     AutoPause_resetTimer
@@ -159,6 +160,7 @@ AutoPause_waitWakeup() {
 }
 
 AutoPause_main() {
+    AP_isEnabled || return
     AutoPause_checkRequest false
     if AutoPause_checkTimer; then
         # Safely pause the server when it is not writing files.
@@ -172,6 +174,7 @@ AutoPause_main() {
 }
 
 AutoPause_end() {
+    AP_isEnabled || return
     AP_clean
     APLog "Service ... stopped"
 }


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

- Fixes an issue with expired ca-certificates.

- Excludes api.steamcmd.net from the proxy.

- Fixes an issue where notifications about the AutoPause service starting were displayed even when AUTO_PAUSE_ENABLE=false.

<!-- What do you want to achieve with this PR? -->

Fix issue #718 

## Choices

<!-- * Why did you solve it like this? -->

## Test instructions

1. set AUTO_PAUSE_ENABLE=true and COMMUNITY=true to environments section of docker-compose.yml.
2. start container service ... `docker compose up -d`
3. see logs ... `docker logs palworld-server -f`

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [ ] I've not introduced breaking changes.
- [ ] My changes do not violate linting rules.
