### PR TITLE
remove different languages, due to google search duplicate page suppr…

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -32,33 +32,7 @@ const config = {
   // may want to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'ko', 'zh', 'nl', 'de', 'pt-PT'],
-    localeConfigs:{
-      en: { 
-        label: 'English', 
-        htmlLang: 'en-US'
-      },
-      ko: { 
-        label: 'Korean', 
-        htmlLang: 'ko-KR' 
-      },
-      zh: {
-        label: 'Simplified Chinese',
-        htmlLang: 'zh-CN',
-      },
-      nl: {
-        label: 'Dutch',
-        htmlLang: 'nl-NL',
-      },
-      de: {
-        label: 'Deutsch',
-        htmlLang: 'de-DE',
-      },
-      'pt-PT': {
-        label: 'Portuguese',
-        htmlLang: 'pt-PT',
-      }
-    }
+    locales: ['en'],
   },
 
   presets: [


### PR DESCRIPTION
This does not remove the languages that have been made before, but disables them temporarily because they are incomplete and google marks them as "duplicate" and deindexes the docs site. 

## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

<!-- What do you want to achieve with this PR? -->

## Choices

<!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

- [ ] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [ ] I've not introduced breaking changes.
- [ ] My changes do not violate linting rules.
