### PR TITLE
Fix Docker Run Typo

### DIFF
--- a/docusaurus/docs/getting-started/quick-setup.md
+++ b/docusaurus/docs/getting-started/quick-setup.md
@@ -126,7 +126,7 @@ docker run -d \
     -e COMMUNITY=false \
     -e SERVER_NAME="palworld-server-docker by Thijs van Loef" \
     -e SERVER_DESCRIPTION="palworld-server-docker by Thijs van Loef" \
-    -e CROSSPLAY_PLATFORMS: "(Steam,Xbox,PS5,Mac)" \
+    -e CROSSPLAY_PLATFORMS="(Steam,Xbox,PS5,Mac)" \
     --restart unless-stopped \
     --stop-timeout 30 \
     thijsvanloef/palworld-server-docker:latest


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
There's a typo in the docker run section of this page; if you attempt to run it, you'll get this error:
docker: invalid reference format: repository name (library/(Steam,Xbox,PS5,Mac)) must be lowercase.

## Choices

Just replace the ":" with "=".

## Test instructions

1. Run the docker run command in the command line of your server of choice

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
