### PR TITLE
init: ensure backup directory is created before chown

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -2,6 +2,8 @@
 # shellcheck source=scripts/helper_functions.sh
 source "/home/steam/server/helper_functions.sh"
 
+mkdir -p /palworld/backups
+
 if [[ "$(id -u)" -eq 0 ]] && [[ "$(id -g)" -eq 0 ]]; then
     if [[ "${PUID}" -ne 0 ]] && [[ "${PGID}" -ne 0 ]]; then
         LogAction "EXECUTING USERMOD"
@@ -21,8 +23,6 @@ if ! [ -w "/palworld" ]; then
     LogError "/palworld is not writable."
     exit 1
 fi
-
-mkdir -p /palworld/backups
 
 # shellcheck source=scripts/autopause/community/init.sh
 source "/home/steam/server/autopause/community/init.sh"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

This prevents the backup directory being owned by root the first time someone uses the container.

## Choices

Simplest way to handle it given the init structure.

## Test instructions

Create a new container with user ENVs set and see that backup is no longer owned by root when running the first time (clean install)

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
