### PR TITLE
Fixed parse error in auto-paused.

### DIFF
--- a/scripts/autopause/community/functions.sh
+++ b/scripts/autopause/community/functions.sh
@@ -5,6 +5,7 @@
 # AutoPause Community vars
 #-------------------------------
 
+declare -r APComm_API_URL="${COMMUNITY_API_URL:-https://api.palworldgame.com/}"
 declare -r APComm_basedir="/home/steam/server/autopause/community"
 declare -r APComm_register_file="${APComm_basedir}/register.json"
 declare -r APComm_update_file="${APComm_basedir}/update.json"
@@ -21,15 +22,17 @@ APComm_jsonUpdate=""
 APComm_API() {
     local api="${1}"
     local data="${2}"
-    local url="https://api.palworldgame.com/${api}"
+    local url="${APComm_API_URL}${api}"
     local accept="Accept: application/json"
     local agent="X-UnrealEngine-Agent"
-    curl -s -L -X POST "${url}" -H "${accept}" -A "${agent}" --json "${data}"
+
+    # Use -sS for silent but show errors, --fail to fail on HTTP errors, --max-time for timeout
+    curl -sS --fail --max-time 10 --retry 2 --retry-delay 1 -L -X POST "${url}" -H "${accept}" -A "${agent}" --json "${data}" 2>&1
 }
 
 APComm_loadJSON() {
     if [ ! -f "${APComm_register_file}" ] || [ ! -f "${APComm_update_file}" ]; then
-        APLog "Captured file not found. Perhaps your mitmproxy server is misconfigured, down, or has lost its connection to api.palworldgames.com."
+        APLog_error "Captured file not found. Perhaps your mitmproxy server is misconfigured, down, or has lost its connection to api.palworldgames.com."
         return 1
     fi
     local -i result=0 delta
@@ -49,36 +52,62 @@ APComm_loadJSON() {
 }
 
 APComm_register() {
-    local data response
-    data=$(echo -n "${APComm_jsonRegister//\"/\"}" | jq ".name|=\"${SERVER_NAME} (paused)\"")
-    response=$(APComm_API "server/register" "${data}")
-    local -i result=$?
-    if [ ${result} -eq 0 ] && [ -n "${response}" ]; then
-        id=$(echo -n "${response//\"/\"}" | jq -r '.server_id')
-        key=$(echo -n "${response//\"/\"}" | jq -r '.update_key')
-        APComm_jsonUpdate=$(echo -n "${APComm_jsonUpdate//\"/\"}" | jq ".server_id|=\"${id}\"" | jq ".update_key|=\"${key}\"")
+    local data response id key
+    
+    if ! data=$(echo "${APComm_jsonRegister}" | jq -c --arg name "${SERVER_NAME} (paused)" '.name = $name'); then
+        APLog_error "Error creating register data JSON"
+        return 1
+    fi
+
+    if ! response=$(APComm_API "server/register" "${data}"); then
+        APLog_error "server/register API call failed: $(printf '%.200s' "${response}")"
+        return 1
+    fi
+
+    if ! echo "${response}" | jq empty > /dev/null 2>&1; then
+        APLog_error "server/register API returned invalid JSON response: $(printf '%.200s' "${response}")"
+        return 1
+    fi
+
+    id=$(echo "${response}" | jq -r '.server_id // empty')
+    key=$(echo "${response}" | jq -r '.update_key // empty')
+
+    if [ -n "${id}" ] && [ -n "${key}" ]; then
+        # Update APComm_jsonUpdate safely
+        APComm_jsonUpdate=$(echo "${APComm_jsonUpdate:-{}}" | jq -c --arg id "${id}" --arg key "${key}" '.server_id = $id | .update_key = $key')
         APLog "Community server registered ID: ${id}"
         return 0
     fi
-    APLog "${response}"
+
+    # Mask sensitive data in log if possible, or just truncate
+    APLog_error "Registration failed (missing id or key): $(printf '%.200s' "${response}")"
     return 1
 }
 
 APComm_update() {
-    response=$(APComm_API "server/update" "${APComm_jsonUpdate}")
-    local -i result=$?
-    if [ ${result} -eq 0 ] && [ -n "${response}" ]; then
-        local message status
-        message=$(echo "${response//\"/\"}" | jq -r '.error_message')
-        status=$(echo "${response//\"/\"}" | jq -r '.status')
-        if [ "${status}" = "ok" ]; then
-            return 0
-        elif [ -n "${message}" ]; then
-            APLog "${status}: ${message}"
-            return 1
-        fi
+    local response message status
+
+    if ! response=$(APComm_API "server/update" "${APComm_jsonUpdate}"); then
+        APLog_error "server/update API call failed: $(printf '%.200s' "${response}")"
+        return 1
     fi
-    APLog "${response}"
+
+    if ! echo "${response}" | jq empty > /dev/null 2>&1; then
+        APLog_error "server/update API returned invalid JSON response: $(printf '%.200s' "${response}")"
+        return 1
+    fi
+
+    status=$(echo "${response}" | jq -r '.status // empty')
+    message=$(echo "${response}" | jq -r '.error_message // empty')
+
+    if [ "${status}" = "ok" ]; then
+        return 0
+    elif [ -n "${message}" ]; then
+        APLog "${status}: ${message}"
+        return 1
+    fi
+
+    APLog_error "Update failed: $(printf '%.200s' "${response}")"
     return 1
 }
 

--- a/scripts/autopause/functions.sh
+++ b/scripts/autopause/functions.sh
@@ -14,11 +14,23 @@ declare -r AP_disable_file="${DATA_DIR}/.autopause-disabled" # for shutdown and 
 #-------------------------------
 
 APLog() {
-    isTrue "${AUTO_PAUSE_LOG:-true}" && LogInfo "[AUTO PAUSE] ${1}"
+    local msg="${1:-(no message)}"
+    isTrue "${AUTO_PAUSE_LOG:-true}" && LogInfo "[AUTO PAUSE] ${msg}"
+}
+
+APLog_warn() {
+    local msg="${1:-(no message)}"
+    isTrue "${AUTO_PAUSE_LOG:-true}" && LogWarn "[AUTO PAUSE] ${msg}"
+}
+
+APLog_error() {
+    local msg="${1:-(no message)}"
+    isTrue "${AUTO_PAUSE_LOG:-true}" && LogError "[AUTO PAUSE] ${msg}"
 }
 
 APLog_debug() {
-    isTrue "${AUTO_PAUSE_DEBUG:-false}" && LogInfo "[AUTO PAUSE DEBUG] ${1}"
+    local msg="${1:-(no message)}"
+    isTrue "${AUTO_PAUSE_DEBUG:-false}" && LogInfo "[AUTO PAUSE DEBUG] ${msg}"
 }
 
 #-------------------------------
@@ -71,7 +83,7 @@ AP_pause() {
     local -r pid=$(pidof PalServer-Linux-Shipping)
     if isTrue "${on}"; then
         if AP_isSleep; then
-            APLog "[WARNING] Already sleeped..."
+            APLog_warn "Already sleeped..."
             return 0
         fi
         APLog "Paused. (PID:${pid})"
@@ -79,7 +91,7 @@ AP_pause() {
         AP_touch on "${AP_pause_file}"
     else
         if ! AP_isSleep; then
-            APLog "[WARNING] Already wakeuped..."
+            APLog_warn "Already wakeuped..."
             return 0
         fi
         APLog "Wakeup!!! (PID:${pid})"

--- a/scripts/autopause/services.sh
+++ b/scripts/autopause/services.sh
@@ -91,7 +91,7 @@ AutoPause_checkRequest() {
             fi
             ;;
         *)
-            APLog "Unkown request ... '${request}'"
+            APLog_error "Unkown request ... '${request}'"
             ;;
         esac
     fi
@@ -123,13 +123,13 @@ AutoPause_preSave() {
 AutoPause_challengeToPause() {
     if isTrue "${COMMUNITY}"; then
         if ! APComm_isCaptured; then
-            APLog "Waiting for capture the community update data before pause."
+            APLog_warn "Waiting for capture the community update data before pause."
             return 1
         fi
     fi
 
     if ! local -r result=$(AutoPause_preSave); then
-        APLog "Save failed before pausing... ${result}"
+        APLog_error "Save failed before pausing... ${result}"
         return 1
     fi
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

- Fixed #769.
- Added log level to AUTO PAUSE.

## Choices

To make it more robust.

## Test instructions

1. `cd examples/autopause`
2. add `compose.override.yml`
    ```yaml
    services:
      palworld:
        environment:
          AUTO_PAUSE_DEBUG: true
          COMMUNITY_API_URL: "https://api.palworldgame.com/test/"
    ```
2. `docker compose up --build`
3. see log
    ```
    [AUTO PAUSE] server/update API call failed: curl: (22) The requested URL returned error: 404
    [AUTO PAUSE] server/register API call failed: curl: (22) The requested URL returned error: 404
    ```

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- ~~[ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).~~
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
