### PR TITLE
feat: add Podman support for auto-pause and fix log flushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,17 @@ This feature can be enabled by setting the environment variable `AUTO_PAUSE_ENAB
 | AUTO_PAUSE_LOG         | Enable auto-pause logging                                                                                                                | true           | true/false     |
 | AUTO_PAUSE_DEBUG       | Enable auto-pause debug logging                                                                                                          | false          | true/false     |
 
+> [!NOTE]
+> When using **Podman**, you must add the `--cap-add=NET_RAW` option to the `run` or `create` command.
+> Alternatively, add the following `cap_add:` to your `compose.yml`:
+>
+> ```yaml
+> services:
+>   palworld:
+>     cap_add:
+>       - NET_RAW
+> ```
+
 ### Resume manually
 
 A file called `.paused` is created in `/palworld` directory when the server is paused and removed when the server is resumed.

--- a/docusaurus/docs/guides/automatic-server-pausing.md
+++ b/docusaurus/docs/guides/automatic-server-pausing.md
@@ -23,6 +23,19 @@ This feature can be enabled by setting the environment variable `AUTO_PAUSE_ENAB
 | AUTO_PAUSE_LOG         | Enable auto-pause logging                                                                                                                | true           | true/false     |
 | AUTO_PAUSE_DEBUG       | Enable auto-pause debug logging                                                                                                          | false          | true/false     |
 
+:::note
+When using **Podman**, you must add the `--cap-add=NET_RAW` option to the `run` or `create` command.
+Alternatively, add the following `cap_add:` to your `compose.yml`:
+
+```yaml
+services:
+  palworld:
+    cap_add:
+      - NET_RAW
+```
+
+:::
+
 ### Resume manually
 
 A file called `.paused` is created in `/palworld` directory when the server is paused and removed when the server is resumed.

--- a/examples/autopause/compose.yml
+++ b/examples/autopause/compose.yml
@@ -4,6 +4,8 @@ services:
       file: ../../docker-compose.yml
       service: palworld
     build: ../../
+    cap_add:
+      - NET_RAW # for podman (docker default has it)
     environment:
       SERVER_NAME: "palworld-server-docker/examples/autopause"
       AUTO_PAUSE_ENABLED: true

--- a/scripts/autopause/init.sh
+++ b/scripts/autopause/init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if isTrue "${AUTO_PAUSE_ENABLED}" && PlayerLogging_isEnabled; then
+    if command -v knockd > /dev/null 2>&1 && ! knockd --version > /dev/null 2>&1; then
+        LogError "AUTO_PAUSE requires NET_RAW capability. e.g) podman run --cap-add=NET_RAW ..."
+        exit 1
+    fi
+
+    # shellcheck source=scripts/autopause/community/init.sh
+    source "/home/steam/server/autopause/community/init.sh"
+fi

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -143,15 +143,19 @@ LogInfo() {
 }
 LogWarn() {
     Log "$1" "$YellowBoldText" "WARN"
+    LogFlush
 }
 LogError() {
     Log "$1" "$RedBoldText" "ERROR"
+    LogFlush
 }
 LogSuccess() {
     Log "$1" "$GreenBoldText" "SUCCESS"
+    LogFlush
 }
 LogAction() {
     Log "****$1****" "$CyanBoldText" "ACTION"
+    LogFlush
 }
 LogFlush() {
     if [ -p "${PalServerLog_fifo}" ]; then

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -28,8 +28,8 @@ if ! [ -w "/palworld" ]; then
     exit 1
 fi
 
-# shellcheck source=scripts/autopause/community/init.sh
-source "/home/steam/server/autopause/community/init.sh"
+# shellcheck source=scripts/autopause/init.sh
+source "/home/steam/server/autopause/init.sh"
 
 # shellcheck disable=SC2317
 term_handler() {


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

- Add NET_RAW capability requirement for Podman in docs and examples for #772.
- Refactor auto-pause initialization to check for required capabilities.
- Ensure important logs (ERROR, WARN, etc.) are flushed immediately.

## Choices

- At startup, knockd is tested and any capability errors are displayed.
```
****EXECUTING USERMOD****
AUTO_PAUSE requires NET_RAW capability. e.g) podman run --cap-add=NET_RAW ...
```

## Test instructions

1. `cd ./examples/autopause`
2. `podman compose up`
3. wait sleep `[AUTO PAUSE] Paused. (PID:159)`
4. connect from PalWorld client to server.
5. see wake up server log. `[AUTO PAUSE] Wakeup!!! (PID:159)`

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
