### PR TITLE
disable log_filter due to restart bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,7 +179,7 @@ ENV HOME=/home/steam \
     CROSSPLAY_PLATFORMS="(Steam,Xbox,PS5,Mac)" \
     USE_DEPOT_DOWNLOADER=false \
     INSTALL_BETA_INSIDER=false \
-    LOG_FILTER_ENABLED=true \
+    LOG_FILTER_ENABLED=false \
     LOG_FORMAT_TYPE=default
 
 # Sane Box64 config defaults


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

<!-- What do you want to achieve with this PR? -->

## Choices

<!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

- [ ] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [ ] I've not introduced breaking changes.
- [ ] My changes do not violate linting rules.
