### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ Please keep in mind that the ENV variables will always overwrite the changes mad
 >
 > Any changes made while the server is live will be overwritten when the server stops.
 >
-> Remember to disable generate settings on the environment variables, or the `PalWorldSettings.ini` file will be 
+> Remember to disable generate settings on the environment variables, or the `PalWorldSettings.ini` file will be
 > overwritten at startup with the default settings. See `DISABLE_GENERATE_SETTINGS` in environment variables.
 
 For a more detailed list of server settings go to: [Palworld Wiki](https://palworld.wiki.gg/wiki/PalWorldSettings.ini)


### PR DESCRIPTION
Clarify manual palworldsettings changes require disabling generate settings in environment variables.

## Context

It took me a while to figure out (after looking at the logs) that the settings were being overwritten by the startup auto generation. Better clarity in this section of the readme will likely help future users some trouble.