### PR TITLE
fix: wrong variable in broadcast non-ASCII check and undefined function in restore error handler

### DIFF
--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -256,7 +256,7 @@ broadcast_command() {
     fi
     # Replaces spaces with underscore
     local message="${1// /_}"
-    if [[ $TEXT = *[![:ascii:]]* ]]; then
+    if [[ $message = *[![:ascii:]]* ]]; then
         LogWarn "Unable to broadcast since the message contains non-ascii characters: \"${message}\""
         return_val=1
     elif ! RCON "broadcast ${message}" > /dev/null; then

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -25,7 +25,7 @@ restore_error_handler() {
         if [[ ${RUN_ANSWER,,} == "y" ]]; then
             rm -rf "$RESTORE_PATH/Saved"
             mv "$TMP_SAVE_PATH/Saved" "$RESTORE_PATH"
-            PrintSuccess "Recovery Complete"
+            LogSuccess "Recovery Complete"
         fi
     fi
 


### PR DESCRIPTION
## Summary

Two small but real bugs in shell scripts:

### 1. `broadcast_command` checks undefined `$TEXT` instead of `$message`

**File:** `scripts/helper_functions.sh:259`

The non-ASCII guard in `broadcast_command` references `$TEXT`, which is never defined in this scope. The variable should be `$message` (assigned on the line above). Because `$TEXT` is always empty, the pattern `*[![:ascii:]]*` never matches, so:

- Non-ASCII broadcast messages are silently sent to RCON, which doesn't support them, causing confusing failures
- The user never sees the helpful warning: *"Unable to broadcast since the message contains non-ascii characters"*

### 2. `restore_error_handler` calls undefined `PrintSuccess`

**File:** `scripts/restore.sh:28`

During error recovery in `restore.sh`, the script calls `PrintSuccess "Recovery Complete"` — but `PrintSuccess` doesn't exist anywhere in the codebase. The correct function is `LogSuccess` (used on lines 77, 100, and 132 of the same file). This causes a `command not found` error right after recovery completes, which could mislead the user into thinking recovery failed.