### PR TITLE
Updated arm to trixie and AMD64 locked to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,10 @@ RUN wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v${RCON_VERSION
     && rm -rf rcon-cli-${RCON_VERSION} \
     && go build -v ./cmd/gorcon
 
-FROM cm2network/steamcmd:root AS base-amd64
+FROM cm2network/steamcmd:root-trixie AS base-amd64
 # Ignoring --platform=arm64 as this is required for the multi-arch build to continue to work on amd64 hosts
 # hadolint ignore=DL3029
-FROM --platform=arm64 sonroyaalmerol/steamcmd-arm64:root-bookworm-2026-06-07 AS base-arm64
-
+FROM --platform=arm64 sonroyaalmerol/steamcmd-arm64:root-trixie-2026-06-07 AS base-arm64
 ARG TARGETARCH
 # Ignoring the lack of a tag here because the tag is defined in the above FROM lines
 # and hadolint isn't aware of those.


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

<!-- What do you want to achieve with this PR? -->
#841 updated to trixie however it removed the base tag so it would just use the newest image instead of the newest trixie.

## Choices

<!-- * Why did you solve it like this? -->
ARM and AMD64 should be on the same version.

## Test instructions

1. Run docker compose --project-directory examples/autopause up --build
1. Verify that no errors occur during the pause.

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
