### PR TITLE
Added logging to failed checks in start.sh

### DIFF
--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -8,7 +8,7 @@ dirExists() {
     local path="$1"
     local return_val=0
     if ! [ -d "${path}" ]; then
-        echo "${path} does not exist."
+        LogError "${path} does not exist."
         return_val=1
     fi
     return "$return_val"
@@ -21,7 +21,7 @@ fileExists() {
     local path="$1"
     local return_val=0
     if ! [ -f "${path}" ]; then
-        echo "${path} does not exist."
+        LogError "${path} does not exist."
         return_val=1
     fi
     return "$return_val"
@@ -34,7 +34,7 @@ isReadable() {
     local path="$1"
     local return_val=0
     if ! [ -e "${path}" ]; then
-        echo "${path} is not readable."
+        LogError "${path} is not readable."
         return_val=1
     fi
     return "$return_val"
@@ -52,12 +52,12 @@ isWritable() {
         if [ -n "${temp_file}" ]; then
             rm -f "${temp_file}"
         else
-            echo "${path} is not writable."
+            LogError "${path} is not writable."
             return_val=1
         fi
     # If it is a file it must be writable
     elif ! [ -w "${path}" ]; then
-        echo "${path} is not writable."
+        LogError "${path} is not writable."
         return_val=1
     fi
     return "$return_val"
@@ -70,7 +70,7 @@ isExecutable() {
     local path="$1"
     local return_val=0
     if ! [ -x "${path}" ]; then
-        echo "${path} is not executable."
+        LogError "${path} is not executable."
         return_val=1
     fi
     return "$return_val"

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -33,7 +33,7 @@ fileExists() {
 isReadable() {
     local path="$1"
     local return_val=0
-    if ! [ -e "${path}" ]; then
+    if ! [ -r "${path}" ]; then
         LogError "${path} is not readable."
         return_val=1
     fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,14 +7,14 @@ source "/home/steam/server/helper_functions.sh"
 source "/home/steam/server/helper_install.sh"
 
 dirExists "/palworld" || exit
-PalworldDirIsReadableAndWritable=true
+PalworldDirIsWritableAndWritable=true
 if ! isWritable "/palworld"; then
-    PalworldDirIsReadableAndWritable=false
+    PalworldDirIsWritableAndWritable=false
 fi
 if ! isExecutable "/palworld"; then
-    PalworldDirIsReadableAndWritable=false
+    PalworldDirIsWritableAndWritable=false
 fi
-isTrue "${PalworldDirIsReadableAndWritable}" || exit
+isTrue "${PalworldDirIsWritableAndWritable}" || exit
 
 cd /palworld || exit
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,14 +7,8 @@ source "/home/steam/server/helper_functions.sh"
 source "/home/steam/server/helper_install.sh"
 
 dirExists "/palworld" || exit
-PalworldDirIsWritableAndWritable=true
-if ! isWritable "/palworld"; then
-    PalworldDirIsWritableAndWritable=false
-fi
-if ! isExecutable "/palworld"; then
-    PalworldDirIsWritableAndWritable=false
-fi
-isTrue "${PalworldDirIsWritableAndWritable}" || exit
+isWritable "/palworld" || exit
+isExecutable "/palworld" || exit
 
 cd /palworld || exit
 
@@ -54,14 +48,8 @@ if [ "$architecture" == "arm64" ]; then
     STARTCOMMAND=("./PalServer-arm64.sh")
 fi
 
-StartCommandIsReadableAndExecutable=true
-if ! isReadable "${STARTCOMMAND[0]}"; then
-    StartCommandIsReadableAndExecutable=false
-fi
-if ! isExecutable "${STARTCOMMAND[0]}"; then
-    StartCommandIsReadableAndExecutable=false
-fi
-isTrue "${StartCommandIsReadableAndExecutable}" || exit
+isReadable "${STARTCOMMAND[0]}" || exit
+isExecutable "${STARTCOMMAND[0]}" || exit
 
 # Prepare Arguments
 if [ -n "${PORT}" ]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,17 +6,12 @@ source "/home/steam/server/helper_functions.sh"
 # shellcheck source=scripts/helper_install.sh
 source "/home/steam/server/helper_install.sh"
 
-if ! dirExists "/palworld"; then
-    LogError "/palworld does not exist"
-    exit 1
-fi
+dirExists "/palworld" || exit
 PalworldDirIsReadableAndWritable=true
 if ! isWritable "/palworld"; then
-    LogError "/palworld is not writable"
     PalworldDirIsReadableAndWritable=false
 fi
 if ! isExecutable "/palworld"; then
-    LogError "/palworld is not executable"
     PalworldDirIsReadableAndWritable=false
 fi
 isTrue "${PalworldDirIsReadableAndWritable}" || exit
@@ -61,11 +56,9 @@ fi
 
 StartCommandIsReadableAndWritable=true
 if ! isReadable "${STARTCOMMAND[0]}"; then;
-    LogError "${STARTCOMMAND[0]} is not readable"
     StartCommandIsReadableAndWritable=false
 fi
 if ! isExecutable "${STARTCOMMAND[0]}"; then
-    LogError "${STARTCOMMAND[0]} is not executable"
     StartCommandIsReadableAndWritable=false
 fi
 isTrue "${StartCommandIsReadableAndWritable}" || exit

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -55,7 +55,7 @@ if [ "$architecture" == "arm64" ]; then
 fi
 
 StartCommandIsReadableAndExecutable=true
-if ! isReadable "${STARTCOMMAND[0]}"; then;
+if ! isReadable "${STARTCOMMAND[0]}"; then
     StartCommandIsReadableAndExecutable=false
 fi
 if ! isExecutable "${STARTCOMMAND[0]}"; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -54,14 +54,14 @@ if [ "$architecture" == "arm64" ]; then
     STARTCOMMAND=("./PalServer-arm64.sh")
 fi
 
-StartCommandIsReadableAndWritable=true
+StartCommandIsReadableAndExecutable=true
 if ! isReadable "${STARTCOMMAND[0]}"; then;
-    StartCommandIsReadableAndWritable=false
+    StartCommandIsReadableAndExecutable=false
 fi
 if ! isExecutable "${STARTCOMMAND[0]}"; then
-    StartCommandIsReadableAndWritable=false
+    StartCommandIsReadableAndExecutable=false
 fi
-isTrue "${StartCommandIsReadableAndWritable}" || exit
+isTrue "${StartCommandIsReadableAndExecutable}" || exit
 
 # Prepare Arguments
 if [ -n "${PORT}" ]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -10,14 +10,16 @@ if ! dirExists "/palworld"; then
     LogError "/palworld does not exist"
     exit 1
 fi
+PalworldDirIsReadableAndWritable=true
 if ! isWritable "/palworld"; then
     LogError "/palworld is not writable"
-    exit 1
+    PalworldDirIsReadableAndWritable=false
 fi
 if ! isExecutable "/palworld"; then
     LogError "/palworld is not executable"
-    exit 1
+    PalworldDirIsReadableAndWritable=false
 fi
+isTrue "${PalworldDirIsReadableAndWritable}" || exit
 
 cd /palworld || exit
 
@@ -57,14 +59,16 @@ if [ "$architecture" == "arm64" ]; then
     STARTCOMMAND=("./PalServer-arm64.sh")
 fi
 
+StartCommandIsReadableAndWritable=true
 if ! isReadable "${STARTCOMMAND[0]}"; then;
     LogError "${STARTCOMMAND[0]} is not readable"
-    exit 1
+    StartCommandIsReadableAndWritable=false
 fi
 if ! isExecutable "${STARTCOMMAND[0]}"; then
     LogError "${STARTCOMMAND[0]} is not executable"
-    exit 1
+    StartCommandIsReadableAndWritable=false
 fi
+isTrue "${StartCommandIsReadableAndWritable}" || exit
 
 # Prepare Arguments
 if [ -n "${PORT}" ]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,9 +6,18 @@ source "/home/steam/server/helper_functions.sh"
 # shellcheck source=scripts/helper_install.sh
 source "/home/steam/server/helper_install.sh"
 
-dirExists "/palworld" || exit
-isWritable "/palworld" || exit
-isExecutable "/palworld" || exit
+if ! dirExists "/palworld"; then
+    LogError "/palworld does not exist"
+    exit 1
+fi
+if ! isWritable "/palworld"; then
+    LogError "/palworld is not writable"
+    exit 1
+fi
+if ! isExecutable "/palworld"; then
+    LogError "/palworld is not executable"
+    exit 1
+fi
 
 cd /palworld || exit
 
@@ -48,8 +57,14 @@ if [ "$architecture" == "arm64" ]; then
     STARTCOMMAND=("./PalServer-arm64.sh")
 fi
 
-isReadable "${STARTCOMMAND[0]}" || exit
-isExecutable "${STARTCOMMAND[0]}" || exit
+if ! isReadable "${STARTCOMMAND[0]}"; then;
+    LogError "${STARTCOMMAND[0]} is not readable"
+    exit 1
+fi
+if ! isExecutable "${STARTCOMMAND[0]}"; then
+    LogError "${STARTCOMMAND[0]} is not executable"
+    exit 1
+fi
 
 # Prepare Arguments
 if [ -n "${PORT}" ]; then


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

<!-- What do you want to achieve with this PR? -->
Fixing #846 


## Choices

<!-- * Why did you solve it like this? -->
Checking two types of permissions before exiting so the user gets both messages instead of fixing the first then running again only to get the second one.

## Test instructions

Disable container restart
Run it with incorrect permissions
Start the container after each step.

Note for step 2: Directories may be writable but not deletable causing -w to return false so for isWritable we check if a file is able to be made but since step 2 permission aren't executable you cannot run mktemp so it counts it as not writable. Keeping it this way as without it we would have the issue presented in #358 

|  # | Action Outside Container | Expected Output |
|--------------------|--------------------------------|------------------------------------|
|  1 | `chmod ugo=r palworld/` | /palworld/ is not writable. /palworld/ is not executable. |
|  2 | `chmod ugo=rw palworld/` | /palworld/ is not executable. /palworld/ is not executable.|
|  3 | `chmod ugo=rx palworld/` | /palworld/ is not writable. |
|  4 | `chmod ugo=rwx palworld/` | Server Starts |
|  5 |  `chmod ugo=rwx palworld/PalServer.sh` | Server Starts |
|  6 | `chmod ugo=w palworld/PalServer.sh` | ./PalServer.sh is not readable. ./PalServer.sh is not executable.|
|  7 | `chmod ugo=r palworld/PalServer.sh` | ./PalServer.sh is not executable. |
|  8 | `chmod ugo=x palworld/PalServer.sh` | ./PalServer.sh is not readable. |


## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
