### PR TITLE
Make discord webhook boolean variables case insensitive

### DIFF
--- a/scripts/discord.sh
+++ b/scripts/discord.sh
@@ -75,7 +75,7 @@ else
     JSON=$(jo embeds[]="$(jo title="\\$TITLE" description="\\$MESSAGE" color=$COLOR)" flags="$DISCORD_FLAGS")
 fi
 
-if [ "$ENABLED" = true ]; then
+if [ "${ENABLED,,}" = true ]; then
     if [ "$URL" == "" ]; then
         DISCORD_URL="$DISCORD_WEBHOOK_URL"
     else


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

Making boolean variables `DISCORD_*_MESSAGE_ENABLED` case insensitive.

## Choices

The same method being used in #261.

## Test instructions

Rebuild image with the change, try using different casing in `DISCORD_*_MESSAGE_ENABLED` variables, see if webhooks are correctly triggered.

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] ~~I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).~~ (No change needed)
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
