### PR TITLE
fix: player join/leave logging for non-Steam (Xbox/PS) user IDs

### DIFF
--- a/scripts/player_logging.sh
+++ b/scripts/player_logging.sh
@@ -11,7 +11,7 @@ get_steamid(){
 
 get_playername(){
     local player_info="${1}"
-    echo "${player_info}" | sed -E 's/,([0-9A-Z]+),[0-9A-Z]+//g'
+    echo "${player_info}" | sed -E 's/,([0-9A-Z]+),[0-9A-Za-z_]+//g'
 }
 
 # Prefer REST API
@@ -37,8 +37,8 @@ while true; do
         # Player IDs are usally 9 or 10 digits however when a player joins for the first time for a given boot their ID is temporary 00000000 (8x zeros or 32x zeros) while loading
         # Player ID is also 00000000 (8x zeros or 32x zeros) when in character creation
         online_players="$(get_players_list | tail -n +2)"
-        mapfile -t current_player_list < <( echo -n "${online_players}" | sed -E '/,(0{8}|0{32}),[0-9A-Z]+/d' | sort )
-        mapfile -t current_no_id_list < <( echo -n "${online_players}" | sed -n -E '/,(0{8}|0{32}),[0-9A-Z]+/p' | sort)
+        mapfile -t current_player_list < <( echo -n "${online_players}" | sed -E '/,(0{8}|0{32}),[0-9A-Za-z_]+/d' | sort )
+        mapfile -t current_no_id_list < <( echo -n "${online_players}" | sed -n -E '/,(0{8}|0{32}),[0-9A-Za-z_]+/p' | sort)
 
         # Players still loading or creating characters
         if [ "${#current_no_id_list[@]}" -gt 0 ]; then


### PR DESCRIPTION
## Context

Fixes player **join/leave** notifications (Discord + in-game broadcast) on **non-Steam** dedicated servers (Xbox / Game Pass, PlayStation).

`scripts/player_logging.sh` parses the player CSV (`name,playerId,userId`) and matches the `userId` field with `[0-9A-Z]+`. That only works for Steam: `convert_JSON_to_CSV_players` strips the `steam_` prefix (`-re 's/"steam_/"/'`), leaving a purely numeric SteamID. Xbox/PS userIds keep their platform prefix — e.g. `gdk_2535445417761848` — which contains lowercase letters and `_`, so `[0-9A-Z]+` never matches.

On non-Steam servers this breaks two things:

1. **Phantom join/leave spam.** The temporary all-zeros player-ID rows (the join handshake / character-creation phase, `,00000000000000000000000000000000,`) are meant to be filtered out by the `sed '/,(0{8}|0{32}),[0-9A-Z]+/d'` lines. Because the trailing `[0-9A-Z]+` can't match `gdk_…`, those rows are **not** filtered, so every real join emits an extra join **and** leave notification for the handshake ID.
2. **Broken names.** `get_playername` can't strip the id/userId, so notifications show the raw CSV row instead of the player name.

Real example from an Xbox Game Pass crossplay server:
> `ZestyAizen,3B737083000000000000000000000000,gdk_2535445417761848 joined the server`

## Choices

Minimal, targeted fix: broaden the `userId` character class from `[0-9A-Z]+` to `[0-9A-Za-z_]+` in the three places that parse it (the two zero-ID filters and `get_playername`). This matches `gdk_`/`psn_`-prefixed IDs while still matching Steam's numeric IDs, so **Steam behaviour is unchanged**. No new dependencies, no config/doc changes.

## Test instructions

1. On a crossplay dedicated server (`CROSSPLAY_PLATFORMS` incl. `Xbox`) with `DISCORD_PLAYER_JOIN_MESSAGE_ENABLED=true`, join from an Xbox/Game Pass client.
2. **Before:** a phantom `<name>,00000…,gdk_… joined` + `… left` pair fires for the handshake ID, and message bodies contain the raw `Name,id,userId` string.
3. **After:** exactly one clean `<name> joined the server` on join and `<name> left the server` on leave, showing just the player name.
4. Steam servers: unchanged (numeric SteamIDs still match).

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the docs (n/a — bug fix, no config/behaviour docs affected)
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
