### PR TITLE
fix(autopause): support WSL2 mirrored networking loopback interface

### DIFF
--- a/scripts/autopause/knockd-ctl.sh
+++ b/scripts/autopause/knockd-ctl.sh
@@ -36,10 +36,12 @@ EOF
     if isTrue "${AUTO_PAUSE_DEBUG:-false}"; then
         knockdArgs+=(-D)
     fi
-    # Detects knocks coming from outside the container.
-    knockd "${knockdArgs[@]}" -i eth0
-    # Detects knocks coming from inside the container.
-    knockd "${knockdArgs[@]}" -i lo
+    # Detects knocks coming from outside, inside and wsl2 loopback of the container.
+    for iface in eth0 lo loopback0; do
+        if ip link show "$iface" >/dev/null 2>&1; then
+            knockd "${knockdArgs[@]}" -i "$iface"
+        fi
+    done
     ;;
 "stop")
     pid=$(pidof knockd)

--- a/scripts/autopause/knockd-ctl.sh
+++ b/scripts/autopause/knockd-ctl.sh
@@ -36,7 +36,7 @@ EOF
     if isTrue "${AUTO_PAUSE_DEBUG:-false}"; then
         knockdArgs+=(-D)
     fi
-    # Detects knocks coming from outside, inside and wsl2 loopback of the container.
+    # Detects knocks coming from outside/inside the container, including WSL2 mirrored networking loopback (loopback0).
     for iface in eth0 lo loopback0; do
         if ip link show "$iface" >/dev/null 2>&1; then
             knockd "${knockdArgs[@]}" -i "$iface"

--- a/scripts/autopause/knockd-ctl.sh
+++ b/scripts/autopause/knockd-ctl.sh
@@ -38,7 +38,7 @@ EOF
     fi
     # Detects knocks coming from outside/inside the container, including WSL2 mirrored networking loopback (loopback0).
     for iface in eth0 lo loopback0; do
-        if ip link show "$iface" >/dev/null 2>&1; then
+        if [ -d "/sys/class/net/${iface}" ]; then
             knockd "${knockdArgs[@]}" -i "$iface"
         fi
     done


### PR DESCRIPTION
## Summary

WSL2 Mirrored Networking routes localhost traffic through the `loopback0` interface instead of the traditional `lo` interface. As a result, `knockd` cannot detect localhost UDP/TCP traffic when listening only on `lo`, preventing Auto Pause from resuming the server for local connections.

This PR starts `knockd` on `loopback0` when the interface exists, while preserving the existing `eth0` and `lo` listeners for compatibility with standard Linux environments.

## Context

This change improves compatibility with WSL2 Mirrored Networking without affecting existing behavior on native Linux installations.

## Choices

Instead of replacing `lo` with `loopback0`, this PR detects whether `loopback0` exists and starts an additional `knockd` instance for that interface.

This approach:

* Preserves existing behavior on standard Linux systems.
* Adds support for WSL2 Mirrored Networking.
* Avoids introducing WSL-specific special cases or breaking existing deployments.

## Test instructions

1. Run the container on a standard Linux host and verify that Auto Pause resumes correctly from both external (`eth0`) and local (`lo`) connections.
2. Run the container under WSL2 with Mirrored Networking enabled.
3. Verify that localhost traffic is routed through `loopback0` and that Auto Pause resumes correctly when connecting via `127.0.0.1`.
4. Confirm that external connections through `eth0` continue to work as before.

## Checklist before requesting a review

* [x] I have performed a self-review/test of my code
* [ ] I've added documentation about this change to the docs.
* [x] I've not introduced breaking changes.
* [x] My changes do not violate linting rules.

## AI Usage Disclosure

* [x] I used ChatGPT to assist in preparing this PR description and implementation.
  I have manually reviewed the generated code and tested the changes locally.
