### PR TITLE
Fixed log FIFO initialization.

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -11,8 +11,27 @@ if ! ValidateNegativeDeltaRecoverySetting; then
 fi
 
 if [ "${LOG_FILTER_ENABLED,,}" = true ]; then
-    # Remove old FIFO to prevent deadlock on restart
+    # Recreate FIFO at every boot to avoid stale descriptors and permission drift.
     rm -f "${PalServerLog_fifo}"
+
+    if ! mkfifo "${PalServerLog_fifo}"; then
+        echo "ERROR: Failed to create log FIFO: ${PalServerLog_fifo}" >&2
+        exit 1
+    fi
+
+    # Keep FIFO owned by steam so child processes can always write.
+    if [[ "$(id -u)" -eq 0 ]]; then
+        if ! chown steam:steam "${PalServerLog_fifo}"; then
+            echo "ERROR: Failed to set log FIFO owner to steam:steam" >&2
+            exit 1
+        fi
+    fi
+
+    if ! chmod 600 "${PalServerLog_fifo}"; then
+        echo "ERROR: Failed to set log FIFO permissions to 600" >&2
+        exit 1
+    fi
+
     exec > >(python3 /home/steam/server/pal_logger.py) 2>&1
 fi
 
@@ -24,6 +43,8 @@ if [[ "$(id -u)" -eq 0 ]] && [[ "$(id -g)" -eq 0 ]]; then
         usermod -o -u "${PUID}" steam
         groupmod -o -g "${PGID}" steam
         chown -R steam:steam /palworld /home/steam/
+        # NOTE: The recursive chown above covers ${PalServerLog_fifo} under /home/steam,
+        # so an explicit second chown/chmod for the FIFO is not required.
     else
         LogError "Running as root is not supported, please fix your PUID and PGID!"
         exit 1

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -14,7 +14,7 @@ if [ "${LOG_FILTER_ENABLED,,}" = true ]; then
     # Recreate FIFO at every boot to avoid stale descriptors and permission drift.
     rm -f "${PalServerLog_fifo}"
 
-    if ! mkfifo "${PalServerLog_fifo}"; then
+    if ! mkfifo -m 600 "${PalServerLog_fifo}"; then
         echo "ERROR: Failed to create log FIFO: ${PalServerLog_fifo}" >&2
         exit 1
     fi
@@ -25,11 +25,6 @@ if [ "${LOG_FILTER_ENABLED,,}" = true ]; then
             echo "ERROR: Failed to set log FIFO owner to steam:steam" >&2
             exit 1
         fi
-    fi
-
-    if ! chmod 600 "${PalServerLog_fifo}"; then
-        echo "ERROR: Failed to set log FIFO permissions to 600" >&2
-        exit 1
     fi
 
     exec > >(python3 /home/steam/server/pal_logger.py) 2>&1

--- a/scripts/pal_logger.py
+++ b/scripts/pal_logger.py
@@ -2,6 +2,7 @@ import sys
 import select
 import os
 import errno
+import stat
 import time
 import signal
 import re
@@ -14,21 +15,14 @@ POLL_PERIOD = int(os.environ.get('PLAYER_LOGGING_POLL_PERIOD', 5))
 TIMEOUT = POLL_PERIOD + 5
 LOG_FORMAT_TYPE = os.environ.get('LOG_FORMAT_TYPE', 'default').lower()
 
-# Setup FIFO
-if os.path.exists(FIFO_PATH):
-    try:
-        os.remove(FIFO_PATH)
-    except OSError:
-        pass
-try:
-    os.mkfifo(FIFO_PATH)
-    # Use 0o600 to restrict access to the owner only.
-    # The owner will be updated to 'steam' by init.sh via chown, ensuring correct access permissions.
-    # We avoid 0o666 to prevent security warnings (e.g. CodeFactor).
-    os.chmod(FIFO_PATH, 0o600)
-except OSError as e:
-    if e.errno != errno.EEXIST:
-        raise
+# FIFO lifecycle (create/remove/chown) is managed by init.sh.
+# pal_logger.py only opens and consumes the FIFO.
+if not os.path.exists(FIFO_PATH):
+    sys.stderr.write(f"FIFO does not exist: {FIFO_PATH}\n")
+    sys.exit(1)
+if not stat.S_ISFIFO(os.stat(FIFO_PATH).st_mode):
+    sys.stderr.write(f"Path is not a FIFO: {FIFO_PATH}\n")
+    sys.exit(1)
 
 # Open FIFO in non-blocking mode for reading
 # We need to open read-write to avoid EOF when the writer closes.
@@ -171,11 +165,6 @@ def cleanup():
         os.close(fifo_fd)
     except (OSError, NameError):
         pass  # Ignore if fifo_fd was never opened
-    if os.path.exists(FIFO_PATH):
-        try:
-            os.remove(FIFO_PATH)
-        except OSError:
-            pass  # Ignore errors if the FIFO does not exist or cannot be removed during cleanup
 
 def signal_handler(signum, frame):
     global running


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

Fix for #865 

## Choices

The log FIFO was being initialized in `pal_logger.py` and processed in the background; depending on the timing, this caused an issue where the owner permissions were not correctly updated.
To resolve this, the log FIFO initialization was moved to `init.sh`, and the code was modified to explicitly set the owner permissions.

## Test instructions

1. Run container with LOG_FILTER_ENABLED=true
2. Check owner permission
    ```bash
    $ docker exec -itu steam palworld-server ls -al .palserver_log_fifo
    prw------- 1 steam steam 0 Jul 23 08:30 .palserver_log_fifo
    ```

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.

## AI Usage Disclosure

Please read the [AI Usage Guidelines for Contributors](AI_GUIDELINES.md) before submitting this PR.
If you used an AI tool to assist in writing or refactoring code for this PR, please disclose it below.

- [x] I used GitHub Copilot to assist in modifications for this PR.
      I have manually reviewed the generated code and tested the container build locally.
