### PR TITLE
Skip Throwaway Server Boot when DISABLE_GENERATE_SETTINGS=true

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -114,15 +114,7 @@ if [ "${DISABLE_GENERATE_SETTINGS,,}" = true ]; then
   # shellcheck disable=SC2143
   if [ ! "$(grep -s '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini)" ]; then
       LogAction "GENERATING CONFIG"
-      # Server will generate all ini files after first run.
-      if [ "$architecture" == "arm64" ]; then
-          timeout --preserve-status 15s ./PalServer-arm64.sh 1> /dev/null
-      else
-          timeout --preserve-status 15s ./PalServer.sh 1> /dev/null
-      fi
-
-      # Wait for shutdown
-      sleep 5
+      mkdir -p /palworld/Pal/Saved/Config/LinuxServer || exit
       cp /palworld/DefaultPalWorldSettings.ini /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
   fi
 else

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -115,7 +115,8 @@ if [ "${DISABLE_GENERATE_SETTINGS,,}" = true ]; then
   if [ ! "$(grep -s '[^[:space:]]' /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini)" ]; then
       LogAction "GENERATING CONFIG"
       mkdir -p /palworld/Pal/Saved/Config/LinuxServer || exit
-      cp /palworld/DefaultPalWorldSettings.ini /palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+      fileExists "/palworld/DefaultPalWorldSettings.ini" || exit
+      cp "/palworld/DefaultPalWorldSettings.ini" "/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini" || exit
   fi
 else
   LogAction "GENERATING CONFIG"


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->
When DISABLE_GENERATE_SETTINGS=true and there's no config yet, the container used to boot the server for 15s, kill it, wait 5s, then boot again for real. That first boot only existed to lay down an empty PalWorldSettings.ini... which then immediately got overwritten anyway. This gets rid of that annoying double-boot.

<!-- What do you want to achieve with this PR? -->

## Choices

<!-- * Why did you solve it like this? -->
The first boot isn't actually needed. DefaultPalWorldSettings.ini already ships with the server install, so we can just mkdir -p the config dir and copy it straight over.

## Test instructions

1. <!-- 1. How did you test this PR? -->
Build the image and run it with -e DISABLE_GENERATE_SETTINGS=true.
It should go straight from GENERATING CONFIG to Starting Server with no reboot cycle.
Confirm Pal/Saved/Config/LinuxServer/PalWorldSettings.ini was created and matches DefaultPalWorldSettings.ini.

## Checklist before requesting a review

- [x ] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [ x] I've not introduced breaking changes.
- [ x] My changes do not violate linting rules.

## AI Usage Disclosure

Please read the [AI Usage Guidelines for Contributors](AI_GUIDELINES.md) before submitting this PR.
If you used an AI tool to assist in writing or refactoring code for this PR, please disclose it below.

- [ ] I used [Tool Name] to assist in modifications for this PR.
      I have manually reviewed the generated code and tested the container build locally.
