### PR TITLE
Handle WorldOption.sav blocking settings on Windows->Linux migration (fixes #886)

### DIFF
--- a/migration/README.md
+++ b/migration/README.md
@@ -7,6 +7,16 @@
 >
 > Please make sure you always have a backup!
 
+> [!IMPORTANT]
+> If you're migrating a save that was ever played on Windows (including via Steam's
+> "host from save data" co-op mode), that save's `WorldOption.sav` takes priority over
+> `PalWorldSettings.ini` and will silently prevent your new server's settings —
+> including `AdminPassword` — from applying. This causes RCON/REST API authentication
+> to fail with "AdminPassword is empty" even when the password is correctly configured
+> everywhere else (see #886). `migrate.sh` (below) handles this automatically by moving
+> any pre-existing `WorldOption.sav` aside; if you migrate manually, do the same
+> yourself (see step 3 in "Manually" below).
+
 1. Find a directory which is named by game server name and contains all saved game data,
    usually it will at `~/Steam/steamapps/common/PalServer/Pal/Saved/SaveGames/0/`
 2. Make sure `migration/migrate.sh`, saved game data directory and mounted volume
@@ -44,4 +54,9 @@
    DedicatedServerName=`2E85FD38BAA792EB1D4C09386F3A3CDA`.
 3. Delete the entire new server save at `PalServer\Pal\Saved\SaveGames\0\<your_save_here>`,
    and replace it with the folder from the old server.
-4. Restart the new server
+4. If the copied save folder contains a `WorldOption.sav` file and the save was ever played on
+   Windows, move (don't delete outright — keep it as a backup) that file out of the way, e.g.
+   `mv WorldOption.sav WorldOption.sav.bak`. Otherwise it takes priority over
+   `PalWorldSettings.ini` and silently blocks your new server's settings (including
+   `AdminPassword`) from applying — see #886.
+5. Restart the new server

--- a/migration/README.md
+++ b/migration/README.md
@@ -15,7 +15,7 @@
 > to fail with "AdminPassword is empty" even when the password is correctly configured
 > everywhere else (see #886). `migrate.sh` (below) handles this automatically by moving
 > any pre-existing `WorldOption.sav` aside; if you migrate manually, do the same
-> yourself (see step 3 in "Manually" below).
+> yourself (see step 4 in "Manually" below).
 
 1. Find a directory which is named by game server name and contains all saved game data,
    usually it will at `~/Steam/steamapps/common/PalServer/Pal/Saved/SaveGames/0/`

--- a/migration/migrate.sh
+++ b/migration/migrate.sh
@@ -21,6 +21,16 @@ docker stop "${CONTAINER_ID}"
 
 cp -r ./"${MIGRATION_SERVER_NAME}" ./palworld/Pal/Saved/SaveGames/0/"${MIGRATION_SERVER_NAME}"/
 
+# A WorldOption.sav carried over from a save that was ever played on Windows takes
+# priority over PalWorldSettings.ini and silently blocks the new server's settings
+# (including AdminPassword) from applying -- see #886. Move it aside rather than
+# deleting it outright, so it's still recoverable if needed.
+WORLD_OPTION_SAV="./palworld/Pal/Saved/SaveGames/0/${MIGRATION_SERVER_NAME}/WorldOption.sav"
+if [ -f "${WORLD_OPTION_SAV}" ]; then
+  echo "########## MOVING ASIDE WorldOption.sav (see #886) ##########"
+  mv "${WORLD_OPTION_SAV}" "${WORLD_OPTION_SAV}.bak"
+fi
+
 sed -i "s/DedicatedServerName=.*/DedicatedServerName=${MIGRATION_SERVER_NAME}/" ./palworld/Pal/Saved/Config/LinuxServer/GameUserSettings.ini
 
 echo "########## STARTING CONTAINER ${CONTAINER_NAME} NOW ##########"


### PR DESCRIPTION
## Context

Fixes #886.

A `WorldOption.sav` carried over from a save that was ever played on Windows (including via Steam's "host from save data" co-op mode) takes priority over `PalWorldSettings.ini` and silently prevents the new server's settings -- including `AdminPassword` -- from applying. This causes RCON and the REST API to reject a correctly-configured admin password with "AdminPassword is empty" / `Authentication failed!`, even when that password is verified correct in the container environment and in the generated `PalWorldSettings.ini`.

#886's original report identified the root cause and confirmed deleting `WorldOption.sav` fixes it, but no code change landed -- the existing `migration/` docs and script don't mention this at all, so anyone following the officially documented migration path still hits it.

## Changes

- `migration/migrate.sh`: after copying the save into place, moves aside (does not delete) any pre-existing `WorldOption.sav` in the migrated save directory, so scripted migrations are unaffected by default.
- `migration/README.md`: documents the same step for manual migrations (new step 4), plus a callout at the top of the script instructions explaining why this matters and linking to #886.

Chose "move aside" (`WorldOption.sav` -> `WorldOption.sav.bak`) rather than deleting outright, so the original file is still recoverable if anyone needs it for reasons unrelated to this bug.

## Verification

Reproduced and fixed against a real production migration (Windows-hosted save -> Linux dedicated server, via this same image):

1. Confirmed `AdminPassword` was correct in the container env and in the freshly-generated `PalWorldSettings.ini` (byte-for-byte, matching quoting) -- RCON and REST API (`/v1/api/info`) both still rejected it.
2. Ruled out a config-regeneration race by setting `DISABLE_GENERATE_SETTINGS=true` and restarting against an untouched, already-correct ini -- symptom persisted identically.
3. Ruled out client-side request formatting by manually constructing the Base64 `Authorization: Basic` header and comparing byte-for-byte against `curl -u`'s automatic handling -- identical, and the server's own 401 response confirmed the failure is server-side (`WWW-Authenticate: Basic realm="Pal"`, body `Unauthorized (AdminPassword is empty)`).
4. Moved `WorldOption.sav` aside (this PR's fix) and restarted -- RCON and REST API immediately worked. Confirmed via the server's own logs: `RCON executed the command. Save`, `RCON executed the command. ShowPlayers`. REST API's `/v1/api/info` and `/v1/api/players` returned real, correctly-authenticated responses. All custom settings (drop-item caps, building limits, invader-enemy toggle, etc.) remained correctly applied from `PalWorldSettings.ini` -- this fix does not reset or lose any other configuration.

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've not introduced breaking changes (the moved-aside file is inert; nothing reads `WorldOption.sav.bak`)
- [x] My changes do not violate linting rules