### PR TITLE
add missing ENABLE_GAMEDATA_API to configmap

### DIFF
--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -133,6 +133,8 @@ data:
   USEAUTH: "True"
   BAN_LIST_URL: "https://api.palworldgame.com/api/banlist.txt"
 
+  ENABLE_GAMEDATA_API: "False"
+
   REST_API_ENABLED: "True"
   SHOW_PLAYER_LIST: "True"
   ENABLE_PREDATOR_BOSS_PAL: "True"


### PR DESCRIPTION
## Small kubernetes adjustment

Hi there! It's been a while. I've setup a server again and I found a very small confusion. ENABLE_GAMEDATA_API is not added in the ConfigMap where every other Config has been added.

## Choices

I've extended the ConfigMap due to inconsistency

## Test instructions

1. Deploy Palworld using kubernetes example
2. Verify that ENABLE_GAMEDATA_API is added in the pod

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.