### PR TITLE
Fixed the CAP_NET_RAW capabilities were not inherited.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcap2-bin libpcap0.8 \
     ca-certificates \
     python3 python3-venv python3-pip \
-    gosu \
     && (apt-get install -y --no-install-recommends libicu76 || apt-get install -y --no-install-recommends libicu72 || apt-get install -y --no-install-recommends libicu67) \
     && (apt-get install -y --no-install-recommends libsdl3-0 || apt-get install -y --no-install-recommends libsdl3-0-0) \
     && apt-get clean \

--- a/examples/autopause/compose.yaml
+++ b/examples/autopause/compose.yaml
@@ -11,7 +11,7 @@ services:
       SERVER_NAME: "palworld-server-docker/examples/autopause"
       AUTO_PAUSE_ENABLED: true
       AUTO_PAUSE_TIMEOUT_EST: 10  # Number of seconds before auto pausing.
-      #AUTO_PAUSE_LOG: true
+      AUTO_PAUSE_LOG: true
       #AUTO_PAUSE_DEBUG: false
       COMMUNITY: true
       #PUBLIC_IP: "${PUBLIC_IP:-}"

--- a/scripts/autopause/community/init.sh
+++ b/scripts/autopause/community/init.sh
@@ -8,7 +8,7 @@ if isTrue "${COMMUNITY}" && isTrue "${AUTO_PAUSE_ENABLED}" && PlayerLogging_isEn
 
     LogInfo "Launch proxy."
     MITMPROXY_ADDONS_DIR="/home/steam/server/autopause/community/addons"
-    IGNORE_HOSTS="api.steamcmd.net,discord.com"
+    IGNORE_HOSTS="api.steamcmd.net,discord.com,api.github.com,.sentry.io"
     IGNORE_HOSTS_PATTERN=$(echo "$IGNORE_HOSTS" | tr ',' '\n' | sed 's/\./\\./g' | paste -sd '|' -)
     MITMPROXY_OPTIONS=(
         "--set" "block_global=false"
@@ -17,7 +17,7 @@ if isTrue "${COMMUNITY}" && isTrue "${AUTO_PAUSE_ENABLED}" && PlayerLogging_isEn
         "-s" "${MITMPROXY_ADDONS_DIR}/PalCommCapture.py"
     )
     if isTrue "${AUTO_PAUSE_DEBUG}"; then
-        mitmweb --web-host 0.0.0.0 "${MITMPROXY_OPTIONS[@]}" &
+        PYTHONUNBUFFERED=1 mitmweb --web-host 0.0.0.0 "${MITMPROXY_OPTIONS[@]}" &
         LogInfo "Web Interface URL: http://localhost:8081/"
     else
         mitmdump "${MITMPROXY_OPTIONS[@]}" > /var/log/mitmdump.log &

--- a/scripts/autopause/community/init.sh
+++ b/scripts/autopause/community/init.sh
@@ -9,7 +9,7 @@ if isTrue "${COMMUNITY}" && isTrue "${AUTO_PAUSE_ENABLED}" && PlayerLogging_isEn
     LogInfo "Launch proxy."
     MITMPROXY_ADDONS_DIR="/home/steam/server/autopause/community/addons"
     IGNORE_HOSTS="api.steamcmd.net,discord.com,api.github.com,.sentry.io"
-    IGNORE_HOSTS_PATTERN=$(echo "$IGNORE_HOSTS" | tr ',' '\n' | sed 's/\./\\./g' | paste -sd '|' -)
+    IGNORE_HOSTS_PATTERN="api\\.steamcmd\\.net|discord\\.com|api\\.github\\.com|(?:.*\\.)?sentry\\.io"
     MITMPROXY_OPTIONS=(
         "--set" "block_global=false"
         "--ssl-insecure"

--- a/scripts/autopause/functions.sh
+++ b/scripts/autopause/functions.sh
@@ -61,7 +61,7 @@ AP_isSleep() {
 
 AP_do() {
     if [[ "$(id -u)" -eq 0 ]]; then
-        setpriv --reuid=steam --regid=steam --init-groups bash -c "${1}"
+        setpriv --reuid=steam --regid=steam --init-groups -- bash -c "${1}"
     else
         eval "${1}"
     fi
@@ -133,48 +133,4 @@ AP_waitPullRequest()
     rm -f "${AP_request_file}"
     APLog_debug "AP_waitPullRequest ... time out."
     return 1
-}
-
-#-------------------------------
-# AutoPause Monitor Backend
-#-------------------------------
-
-APMonitor_detectAvailableBackend() {
-    local monitorBackend
-    # Decide monitor backend at startup and persist it for services.sh.
-    # Priority:
-    #   1. NFLOG (requires iptables + tcpdump + NET_RAW,NET_ADMIN capability)
-    #   2. knockd (requires knockd binary + NET_RAW capability)
-    #   3. Error (no suitable backend available)
-    if command -v iptables > /dev/null 2>&1 && iptables -L > /dev/null 2>&1 && \
-       command -v tcpdump > /dev/null 2>&1 && tcpdump --version > /dev/null 2>&1; then
-        monitorBackend="nflog"
-        APLog "AUTO_PAUSE packet monitor: NFLOG (iptables+tcpdump) available."
-    else
-        APLog "AUTO_PAUSE packet monitor: NFLOG (iptables+tcpdump) unavailable."
-        APLog_warn "NET_ADMIN & NET_RAW capability required for NFLOG. e.g) podman run --cap-add=NET_ADMIN --cap-add=NET_RAW ..."
-        if command -v knockd > /dev/null 2>&1 && knockd --version > /dev/null 2>&1; then
-            monitorBackend="knockd"
-            APLog "AUTO_PAUSE packet monitor: knockd available."
-        else
-            APLog "AUTO_PAUSE packet monitor: knockd unavailable."
-            APLog_error "AUTO_PAUSE requires NET_RAW capability. e.g) podman run --cap-add=NET_RAW ..."
-            return 1
-        fi
-    fi
-
-    printf '%s\n' "${monitorBackend}" > "${AP_monitor_backend_file}"
-    chmod 0644 "${AP_monitor_backend_file}" || true
-    if [ "$(id -u)" -eq 0 ]; then
-        chown steam:steam "${AP_monitor_backend_file}" || true
-    fi
-    return 0
-}
-
-APMonitor_determineBackend() {
-    if [ -r "${AP_monitor_backend_file}" ]; then
-        cat "${AP_monitor_backend_file}"
-    else
-        echo "knockd"
-    fi
 }

--- a/scripts/autopause/functions.sh
+++ b/scripts/autopause/functions.sh
@@ -61,7 +61,7 @@ AP_isSleep() {
 
 AP_do() {
     if [[ "$(id -u)" -eq 0 ]]; then
-        gosu steam bash -c "${1}"
+        setpriv --reuid=steam --regid=steam --init-groups bash -c "${1}"
     else
         eval "${1}"
     fi

--- a/scripts/autopause/functions.sh
+++ b/scripts/autopause/functions.sh
@@ -8,7 +8,6 @@ declare -r DATA_DIR="${DATA_DIR:-/palworld}"
 declare -r AP_pause_file="${DATA_DIR}/.paused"
 declare -r AP_request_file="${DATA_DIR}/.autopause-request"
 declare -r AP_disable_file="${DATA_DIR}/.autopause-disabled" # for shutdown and reboot
-declare -r AP_monitor_backend_file="/home/steam/server/autopause/.monitor-backend"
 
 #-------------------------------
 # AutoPause Log

--- a/scripts/autopause/init.sh
+++ b/scripts/autopause/init.sh
@@ -11,7 +11,7 @@ if isTrue "${AUTO_PAUSE_ENABLED}"; then
 
     if ! setpriv --reuid=steam --regid=steam --init-groups -- /usr/local/sbin/knockd-ctl check; then
         # OMV8? (https://github.com/thijsvanloef/palworld-server-docker/issues/911)
-        FORCE_CAPS=(--inh-caps=+net_raw,+net_admin --ambient-caps=+net_raw,+net_admin)
+        FORCE_CAPS=("--inh-caps=+net_raw,+net_admin" "--ambient-caps=+net_raw,+net_admin")
         if ! setpriv --reuid=steam --regid=steam --init-groups "${FORCE_CAPS[@]}" -- /usr/local/sbin/knockd-ctl check; then
             LogError "AUTO_PAUSE requires capabilities the NET_RAW and NET_ADMIN."
             LogError "See NOTE: https://palworld-server-docker.loef.dev/guides/automatic-server-pausing#network-interface-configuration"

--- a/scripts/autopause/init.sh
+++ b/scripts/autopause/init.sh
@@ -9,9 +9,17 @@ if isTrue "${AUTO_PAUSE_ENABLED}"; then
         exit 1
     fi
 
-    if ! APMonitor_detectAvailableBackend; then
-        LogError "AUTO_PAUSE requires either KNOCKD or NFLOG to be available."
-        exit 1
+    if ! setpriv --reuid=steam --regid=steam --init-groups -- /usr/local/sbin/knockd-ctl check; then
+        # OMV8? (https://github.com/thijsvanloef/palworld-server-docker/issues/911)
+        FORCE_CAPS=(--inh-caps=+net_raw,+net_admin --ambient-caps=+net_raw,+net_admin)
+        if ! setpriv --reuid=steam --regid=steam --init-groups "${FORCE_CAPS[@]}" -- /usr/local/sbin/knockd-ctl check; then
+            LogError "AUTO_PAUSE requires capabilities the NET_RAW and NET_ADMIN."
+            LogError "See NOTE: https://palworld-server-docker.loef.dev/guides/automatic-server-pausing#network-interface-configuration"
+            exit 1
+        else
+            LogWarn "A capability issue #911 was detected."
+            LogWarn "Continuing with NET_RAW and NET_ADMIN capabilities enabled."
+        fi
     fi
 
     # shellcheck source=scripts/autopause/community/init.sh

--- a/scripts/autopause/knockd-ctl.sh
+++ b/scripts/autopause/knockd-ctl.sh
@@ -27,6 +27,7 @@ Knockd_interfaces="${AUTO_PAUSE_KNOCKD_IF:-auto}"
 Nflog_interfaces=(any)  # NFLOG backend always uses "any" to match all incoming packets via iptables rules.
 
 declare -a Knockd_resolvedInterfaces=()
+declare -r AP_monitor_backend_file="/home/steam/server/autopause/.monitor-backend"
 
 # Add an interface to the Knockd_resolvedInterfaces array if it exists and is not already present.
 # Validates interface exists via /sys/class/net and prevents duplicates.

--- a/scripts/autopause/knockd-ctl.sh
+++ b/scripts/autopause/knockd-ctl.sh
@@ -370,6 +370,50 @@ Knockd_stopBackend() {
     done
 }
 
+#-------------------------------
+# AutoPause Monitor Backend
+#-------------------------------
+
+APMonitor_detectAvailableBackend() {
+    local monitorBackend
+    # Decide monitor backend at startup and persist it for services.sh.
+    # Priority:
+    #   1. NFLOG (requires iptables + tcpdump + NET_RAW,NET_ADMIN capability)
+    #   2. knockd (requires knockd binary + NET_RAW capability)
+    #   3. Error (no suitable backend available)
+    if command -v iptables > /dev/null 2>&1 && iptables -L > /dev/null 2>&1 && \
+       command -v tcpdump > /dev/null 2>&1 && tcpdump --version > /dev/null 2>&1; then
+        monitorBackend="nflog"
+        APLog "AUTO_PAUSE packet monitor: NFLOG (iptables+tcpdump) available."
+    else
+        APLog "AUTO_PAUSE packet monitor: NFLOG (iptables+tcpdump) unavailable."
+        APLog_warn "NET_ADMIN & NET_RAW capability required for NFLOG. e.g) podman run --cap-add=NET_ADMIN --cap-add=NET_RAW ..."
+        if command -v knockd > /dev/null 2>&1 && knockd --version > /dev/null 2>&1; then
+            monitorBackend="knockd"
+            APLog "AUTO_PAUSE packet monitor: knockd available."
+        else
+            APLog "AUTO_PAUSE packet monitor: knockd unavailable."
+            APLog_error "AUTO_PAUSE requires NET_RAW capability. e.g) podman run --cap-add=NET_RAW ..."
+            return 1
+        fi
+    fi
+
+    printf '%s\n' "${monitorBackend}" > "${AP_monitor_backend_file}"
+    chmod 0644 "${AP_monitor_backend_file}" || true
+    if [ "$(id -u)" -eq 0 ]; then
+        chown steam:steam "${AP_monitor_backend_file}" || true
+    fi
+    return 0
+}
+
+APMonitor_determineBackend() {
+    if [ -r "${AP_monitor_backend_file}" ]; then
+        cat "${AP_monitor_backend_file}"
+    else
+        echo "knockd"
+    fi
+}
+
 # ============================================================================
 # Main Dispatcher
 # ============================================================================
@@ -393,9 +437,15 @@ case "${COMMAND}" in
         Knockd_stopBackend
     fi
     ;;
+"check")
+    APMonitor_detectAvailableBackend
+    ;;
 *)
     echo "Usage: $(basename "${0}") <command>"
     echo "command:"
     echo "    start ... launch NFLOG or knockd based on .monitor-backend"
     echo "    stop  ... stop NFLOG or knockd"
+    echo "    check ... detect available backend and write to .monitor-backend"
+    exit 1
+    ;;
 esac

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -424,3 +424,18 @@ get_latest_version() {
     echo "$latest_version"
 }
 
+fork_as_user() {
+    local -ar cmd=("$@")
+    if [[ "$(id -u)" -eq 0 ]]; then
+        local current_caps caps
+        local -a caps_list
+        current_caps="$(capsh --print | grep '^Current:')"
+        caps_list=()
+        echo "$current_caps" | grep -qw 'cap_net_raw' && caps_list+=("+net_raw")
+        echo "$current_caps" | grep -qw 'cap_net_admin' && caps_list+=("+net_admin")
+        caps=$(IFS=, ; echo "${caps_list[*]}")
+        setpriv --reuid=steam --regid=steam --init-groups --inh-caps="$caps" --ambient-caps="$caps" "${cmd[@]}" &
+    else
+        exec "${cmd[@]}" &
+    fi
+}

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -423,19 +423,3 @@ get_latest_version() {
 
     echo "$latest_version"
 }
-
-fork_as_user() {
-    local -ar cmd=("$@")
-    if [[ "$(id -u)" -eq 0 ]]; then
-        local current_caps caps
-        local -a caps_list
-        current_caps="$(capsh --print | grep '^Current:')"
-        caps_list=()
-        echo "$current_caps" | grep -qw 'cap_net_raw' && caps_list+=("+net_raw")
-        echo "$current_caps" | grep -qw 'cap_net_admin' && caps_list+=("+net_admin")
-        caps=$(IFS=, ; echo "${caps_list[*]}")
-        setpriv --reuid=steam --regid=steam --init-groups --inh-caps="$caps" --ambient-caps="$caps" "${cmd[@]}" &
-    else
-        exec "${cmd[@]}" &
-    fi
-}

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -10,10 +10,11 @@ if ! ValidateNegativeDeltaRecoverySetting; then
     exit 1
 fi
 
+# Remove old FIFO
+rm -f "${PalServerLog_fifo}"
+
 if [ "${LOG_FILTER_ENABLED,,}" = true ]; then
     # Recreate FIFO at every boot to avoid stale descriptors and permission drift.
-    rm -f "${PalServerLog_fifo}"
-
     if ! mkfifo -m 600 "${PalServerLog_fifo}"; then
         echo "ERROR: Failed to create log FIFO: ${PalServerLog_fifo}" >&2
         exit 1

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -73,11 +73,8 @@ term_handler() {
 
 trap 'term_handler' SIGTERM
 
-if [[ "$(id -u)" -eq 0 ]]; then
-    gosu steam ./start.sh &
-else
-    ./start.sh &
-fi
+fork_as_user ./start.sh
+
 # Process ID of start.sh
 killpid="$!"
 wait "$killpid"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -55,6 +55,8 @@ if ! [ -w "/palworld" ]; then
     exit 1
 fi
 
+FORCE_CAPS=()
+
 # shellcheck source=scripts/autopause/init.sh
 source "/home/steam/server/autopause/init.sh"
 
@@ -74,7 +76,12 @@ term_handler() {
 
 trap 'term_handler' SIGTERM
 
-fork_as_user ./start.sh
+if [[ "$(id -u)" -eq 0 ]]; then
+    # Only if the capabilities set on the executable do not work, we reluctantly add NET_ADMIN and NET_RAW capabilities.
+    setpriv --reuid=steam --regid=steam --init-groups "${FORCE_CAPS[@]}" ./start.sh &
+else
+    ./start.sh &
+fi
 
 # Process ID of start.sh
 killpid="$!"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -171,11 +171,7 @@ EOL
 
 CHILD_PIDS=()
 if PlayerLogging_isEnabled; then
-    if [[ "$(id -u)" -eq 0 ]]; then
-        gosu steam /home/steam/server/player_logging.sh &
-    else
-        /home/steam/server/player_logging.sh &
-    fi
+    fork_as_user "/home/steam/server/player_logging.sh"
     CHILD_PIDS+=($!)
 fi
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -154,8 +154,10 @@ if [ "${AUTO_REBOOT_ENABLED,,}" = true ] && [ "${REST_API_ENABLED,,}" = true ]; 
     supercronic -quiet -test -no-reap "/home/steam/server/crontab" || exit
 fi
 
+CRON_PID=""
 if [ -s "/home/steam/server/crontab" ]; then
     supercronic -passthrough-logs -no-reap "/home/steam/server/crontab" &
+    CRON_PID=$!
     LogInfo "Cronjobs started"
 else
     LogInfo "No Cronjobs found"
@@ -171,7 +173,11 @@ EOL
 
 CHILD_PIDS=()
 if PlayerLogging_isEnabled; then
-    fork_as_user "/home/steam/server/player_logging.sh"
+    if [ "$(id -u)" -eq 0 ]; then
+        setpriv --reuid=steam --regid=steam --init-groups "${FORCE_CAPS[@]}" /home/steam/server/player_logging.sh &
+    else
+        /home/steam/server/player_logging.sh &
+    fi
     CHILD_PIDS+=($!)
 fi
 
@@ -182,6 +188,12 @@ echo "${STARTCOMMAND[*]}"
 "${STARTCOMMAND[@]}"
 
 LogAction "Ending Server"
+
+if [ -n "$CRON_PID" ]; then
+    LogInfo "Stopping cronjobs"
+    kill -SIGTERM "$CRON_PID" 2>/dev/null
+fi
+
 if [ ${#CHILD_PIDS[@]} -ne 0 ]; then
     wait "${CHILD_PIDS[@]}"
 fi


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

1. Fixed for #911 
    Containers are governed by the host OS's capabilities.
    It was necessary to properly specify capabilities when switching from root to a user.

2. Fixed an issue where the access token was not immediately displayed due to Python log buffering when `COMMUNITY=true` and `AUTO_PAUSE_DEBUG=true` were used.

3. Ultimately, this became an alternative implementation for #908.

## Choices

- :x: `su -c steam <cmd>`
- :o: `setpriv --reuid=steam --regid=steam --init-groups --inh-caps="$caps" --ambient-caps="$caps" <cmd>`

## Test instructions

1.  Add `AUTO_PAUSE_DEBUG=true` env var to `examples/autopause/compose.yaml` .
2. Run on an actual Debian Trixie host,
    `docker compose --project-directory examples/autopause up`
3. Verify token message in log.
4. Verify that no permission error occurs during PAUSE.

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] No documentation updates are required for this fix.
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.

## AI Usage Disclosure

Please read the [AI Usage Guidelines for Contributors](AI_GUIDELINES.md) before submitting this PR.
If you used an AI tool to assist in writing or refactoring code for this PR, please disclose it below.

- [x] I used GitHub Copilot to assist in modifications for this PR.
      I have manually reviewed the generated code and tested the container build locally.
