### PR TITLE
fix: fall back to AdminPassword from PalWorldSettings.ini when ADMIN_PASSWORD is unset

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Test negative delta recovery setting
         run: ./tests/test-negative-delta-recovery.sh
 
+      - name: Test admin password resolution
+        run: ./tests/test-admin-password.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/docusaurus/docs/getting-started/configuration/game-settings.md
+++ b/docusaurus/docs/getting-started/configuration/game-settings.md
@@ -160,6 +160,10 @@ Changes can only be made to `PalWorldSettings.ini` while the server is off.
 Any changes made while the server is live will be overwritten when the server stops.
 :::
 
+When `ADMIN_PASSWORD` is not set, the `AdminPassword` from `PalWorldSettings.ini` is used to authenticate
+the container against the REST API, so auto reboots, backups and graceful shutdowns keep working when the
+admin password is only set in the file. `ADMIN_PASSWORD` still takes precedence whenever it is set.
+
 For a more detailed list of server settings go to: [Palworld Wiki](https://palworld.wiki.gg/wiki/PalWorldSettings.ini)
 
 For more detailed server settings explanations go to: [shockbyte](https://shockbyte.com/billing/knowledgebase/1189/How-to-Configure-your-Palworld-server.html)

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -255,13 +255,51 @@ DiscordMessage() {
   fi
 }
 
+# Reads AdminPassword from the given settings file, defaulting to PalWorldSettings.ini
+# Only the quoted form written by the server and by compile-settings.sh is matched
+# Returns 0 and prints the password if one is set
+# Returns 1 if the file is unreadable or holds no AdminPassword
+get_admin_password_from_settings() {
+    local -r config_file="${1:-/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini}"
+    local -r pattern='AdminPassword="([^"]*)"'
+    local settings
+
+    if [ ! -r "${config_file}" ]; then
+        return 1
+    fi
+
+    settings="$(tr -d '\r' < "${config_file}")"
+    if [[ "${settings}" =~ $pattern ]] && [ -n "${BASH_REMATCH[1]}" ]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+
+    return 1
+}
+
+# Returns the password used to authenticate against the server's own REST API
+# ADMIN_PASSWORD wins when it is set, so this changes nothing for existing setups
+# With DISABLE_GENERATE_SETTINGS=true the .ini is the source of truth and ADMIN_PASSWORD
+# is commonly left unset, which makes every container side call (auto reboot, backup,
+# graceful shutdown) fail with "Unauthorized"; fall back to the .ini in that case
+# Takes an optional settings file path, only used by the tests
+# shellcheck disable=SC2120
+get_admin_password() {
+    if [ -n "${ADMIN_PASSWORD:-}" ]; then
+        printf '%s' "${ADMIN_PASSWORD}"
+        return 0
+    fi
+
+    get_admin_password_from_settings "$@"
+}
+
 # REST API Call
 REST_API() {
     autopause resume "REST_API ${1}" > /dev/null
     local -r api="${1}"
     local -r data="${2}"
     local -r url="http://localhost:${REST_API_PORT}/v1/api/${api}"
-    local -r userpass="admin:${ADMIN_PASSWORD}"
+    local -r userpass="admin:$(get_admin_password)"
     local -r post_api="save|stop"
     local -r down_api="shutdown|stop"
     local -i result=0

--- a/scripts/helper_functions.sh
+++ b/scripts/helper_functions.sh
@@ -261,16 +261,27 @@ DiscordMessage() {
 # Returns 1 if the file is unreadable or holds no AdminPassword
 get_admin_password_from_settings() {
     local -r config_file="${1:-/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini}"
-    local -r pattern='AdminPassword="([^"]*)"'
-    local settings
+    local -r pattern='AdminPassword[[:space:]]*=[[:space:]]*"([^"]*)"'
+    local line password=""
 
     if [ ! -r "${config_file}" ]; then
         return 1
     fi
 
-    settings="$(tr -d '\r' < "${config_file}")"
-    if [[ "${settings}" =~ $pattern ]] && [ -n "${BASH_REMATCH[1]}" ]; then
-        printf '%s' "${BASH_REMATCH[1]}"
+    # Commented out lines are skipped and the last value wins, so a file that keeps
+    # an old or empty AdminPassword above the live one still resolves correctly
+    while IFS= read -r line; do
+        line="${line//$'\r'/}"
+        if [[ "${line}" =~ ^[[:space:]]*[\;#] ]]; then
+            continue
+        fi
+        if [[ "${line}" =~ $pattern ]] && [ -n "${BASH_REMATCH[1]}" ]; then
+            password="${BASH_REMATCH[1]}"
+        fi
+    done < "${config_file}"
+
+    if [ -n "${password}" ]; then
+        printf '%s' "${password}"
         return 0
     fi
 
@@ -291,6 +302,13 @@ get_admin_password() {
     fi
 
     get_admin_password_from_settings "$@"
+}
+
+# Renders the given value as a YAML single quoted scalar
+# Single quoted scalars process no escape sequences, only a literal quote is doubled,
+# so a password holding a backslash or a double quote survives unchanged
+yaml_single_quoted() {
+    printf "'%s'" "${1//\'/\'\'}"
 }
 
 # REST API Call

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -165,10 +165,13 @@ fi
 
 # Configure RCON settings.
 # DEPRECATED: RCON will be removed in a future release.
+# The password is written as a YAML single quoted scalar so that a backslash or a
+# double quote in it does not get re-interpreted or break the file for rcon-cli
+rcon_password="$(yaml_single_quoted "$(get_admin_password)")"
 cat >/home/steam/server/rcon.yaml  <<EOL
 default:
   address: "127.0.0.1:${RCON_PORT}"
-  password: "$(get_admin_password)"
+  password: ${rcon_password}
 EOL
 
 CHILD_PIDS=()

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -118,6 +118,10 @@ if [ "${DISABLE_GENERATE_SETTINGS,,}" = true ]; then
       fileExists "/palworld/DefaultPalWorldSettings.ini" || exit
       cp "/palworld/DefaultPalWorldSettings.ini" "/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini" || exit
   fi
+
+  if [ -z "${ADMIN_PASSWORD}" ] && get_admin_password_from_settings > /dev/null; then
+      LogInfo "ADMIN_PASSWORD is not set, using AdminPassword from PalWorldSettings.ini to authenticate against the REST API"
+  fi
 else
   LogAction "GENERATING CONFIG"
   LogInfo "Using Env vars to create PalWorldSettings.ini"
@@ -164,7 +168,7 @@ fi
 cat >/home/steam/server/rcon.yaml  <<EOL
 default:
   address: "127.0.0.1:${RCON_PORT}"
-  password: "${ADMIN_PASSWORD}"
+  password: "$(get_admin_password)"
 EOL
 
 CHILD_PIDS=()

--- a/tests/test-admin-password.sh
+++ b/tests/test-admin-password.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -eo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/helper_functions.sh
+source "${repo_root}/scripts/helper_functions.sh"
+
+settings_file="$(mktemp)"
+trap 'rm -f "${settings_file}"' EXIT
+
+fail() {
+    echo "test failure: $*" >&2
+    exit 1
+}
+
+# Writes a single line settings file, the same shape compile-settings.sh produces
+write_settings() {
+    printf '[/Script/Pal.PalGameWorldSettings]\nOptionSettings=(Difficulty=None,ServerPassword="%s",AdminPassword=%s,PublicPort=8211)\n' "$1" "$2" > "${settings_file}"
+}
+
+assert_password_from_settings() {
+    write_settings "serverPass" '"adminPass"'
+    local password
+    password="$(get_admin_password_from_settings "${settings_file}")" || fail "no password read from the settings file"
+    [ "${password}" = "adminPass" ] || fail "expected adminPass, got ${password}"
+}
+
+assert_special_characters_are_kept() {
+    write_settings "serverPass" '"p@ss w0rd$&=,"'
+    local password
+    password="$(get_admin_password_from_settings "${settings_file}")" || fail "no password read from the settings file"
+    [ "${password}" = 'p@ss w0rd$&=,' ] || fail "expected p@ss w0rd\$&=, got ${password}"
+}
+
+assert_carriage_returns_are_stripped() {
+    printf 'OptionSettings=(AdminPassword="adminPass")\r\n' > "${settings_file}"
+    local password
+    password="$(get_admin_password_from_settings "${settings_file}")" || fail "no password read from the settings file"
+    [ "${password}" = "adminPass" ] || fail "carriage return was not stripped from ${password}"
+}
+
+assert_empty_password_is_rejected() {
+    write_settings "serverPass" '""'
+    if get_admin_password_from_settings "${settings_file}"; then
+        fail "an empty AdminPassword was accepted"
+    fi
+}
+
+assert_missing_file_is_rejected() {
+    if get_admin_password_from_settings "${settings_file}.missing"; then
+        fail "a missing settings file was accepted"
+    fi
+}
+
+assert_environment_variable_wins() {
+    write_settings "serverPass" '"adminPass"'
+    ADMIN_PASSWORD="fromEnvironment"
+    local password
+    password="$(get_admin_password "${settings_file}")" || fail "no password returned"
+    [ "${password}" = "fromEnvironment" ] || fail "expected fromEnvironment, got ${password}"
+    unset ADMIN_PASSWORD
+}
+
+assert_settings_are_used_when_environment_variable_is_empty() {
+    write_settings "serverPass" '"adminPass"'
+    ADMIN_PASSWORD=""
+    local password
+    password="$(get_admin_password "${settings_file}")" || fail "no password returned"
+    [ "${password}" = "adminPass" ] || fail "expected adminPass, got ${password}"
+    unset ADMIN_PASSWORD
+}
+
+assert_unset_environment_variable_is_tolerated() {
+    unset ADMIN_PASSWORD
+    if get_admin_password "${settings_file}.missing" > /dev/null; then
+        fail "a password was returned without ADMIN_PASSWORD and without a settings file"
+    fi
+}
+
+assert_password_from_settings
+assert_special_characters_are_kept
+assert_carriage_returns_are_stripped
+assert_empty_password_is_rejected
+assert_missing_file_is_rejected
+assert_environment_variable_wins
+assert_settings_are_used_when_environment_variable_is_empty
+assert_unset_environment_variable_is_tolerated
+
+echo "admin password tests passed"

--- a/tests/test-admin-password.sh
+++ b/tests/test-admin-password.sh
@@ -78,11 +78,44 @@ assert_unset_environment_variable_is_tolerated() {
     fi
 }
 
+assert_whitespace_around_the_assignment_is_tolerated() {
+    printf 'OptionSettings=(AdminPassword = "adminPass")\n' > "${settings_file}"
+    local password
+    password="$(get_admin_password_from_settings "${settings_file}")" || fail "no password read from the settings file"
+    [ "${password}" = "adminPass" ] || fail "expected adminPass, got ${password}"
+}
+
+assert_commented_lines_are_ignored() {
+    printf ';OptionSettings=(AdminPassword="commentedOut")\nOptionSettings=(AdminPassword="adminPass")\n' > "${settings_file}"
+    local password
+    password="$(get_admin_password_from_settings "${settings_file}")" || fail "no password read from the settings file"
+    [ "${password}" = "adminPass" ] || fail "expected adminPass, got ${password}"
+}
+
+assert_an_empty_value_does_not_hide_a_later_one() {
+    printf 'OptionSettings=(AdminPassword="")\nOptionSettings=(AdminPassword="adminPass")\n' > "${settings_file}"
+    local password
+    password="$(get_admin_password_from_settings "${settings_file}")" || fail "no password read from the settings file"
+    [ "${password}" = "adminPass" ] || fail "expected adminPass, got ${password}"
+}
+
+assert_yaml_scalar_survives_backslashes_and_quotes() {
+    local quoted
+    quoted="$(yaml_single_quoted 'pa\ss"w0rd')"
+    [ "${quoted}" = "'pa\\ss\"w0rd'" ] || fail "expected 'pa\\ss\"w0rd', got ${quoted}"
+    quoted="$(yaml_single_quoted "it's a p@ss")"
+    [ "${quoted}" = "'it''s a p@ss'" ] || fail "expected 'it''s a p@ss', got ${quoted}"
+}
+
 assert_password_from_settings
 assert_special_characters_are_kept
 assert_carriage_returns_are_stripped
 assert_empty_password_is_rejected
 assert_missing_file_is_rejected
+assert_whitespace_around_the_assignment_is_tolerated
+assert_commented_lines_are_ignored
+assert_an_empty_value_does_not_hide_a_later_one
+assert_yaml_scalar_survives_backslashes_and_quotes
 assert_environment_variable_wins
 assert_settings_are_used_when_environment_variable_is_empty
 assert_unset_environment_variable_is_tolerated


### PR DESCRIPTION
## What this fixes

Every container side REST API call authenticates with `admin:${ADMIN_PASSWORD}`
(`helper_functions.sh` `REST_API()`). That is the only source of the credential.

When `DISABLE_GENERATE_SETTINGS=true`, `compile-settings.sh` never runs, so the `.ini`
becomes the source of truth and nothing populates `ADMIN_PASSWORD` from it. There is no
`.ini` → env path in the image. For anyone who sets the admin password only in
`PalWorldSettings.ini` — which is exactly what the `DISABLE_GENERATE_SETTINGS` docs tell
users to do — `ADMIN_PASSWORD` stays empty and every REST call returns `Unauthorized`.

Two user visible consequences:

1. **Auto reboot never runs.** `auto_reboot.sh` gets a 401 on `get_player_count` (which
   returns `0` with rc 0, so the players-online guard passes silently), then
   `shutdown_server` refuses to shut down because `save_server` 401s — "Do not shutdown if
   not able to save". The cron job exits 1 a couple of seconds after it starts, with no
   error beyond supercronic's own line:

   ```text
   level=info msg=starting job.command="bash /home/steam/server/auto_reboot.sh" job.schedule="0 5 * * *"
   [ERROR] error running command: exit status 1
   ```

2. **No graceful shutdown ever saves.** `init.sh` `term_handler` calls the same
   `shutdown_server`; when it fails it falls through to
   `kill -SIGTERM "$(pidof PalServer-Linux-Shipping)"` under a `# Does not save` comment. So
   `docker stop`, restarts and redeploys all discard everything since the last autosave.

Same root cause for `rcon.yaml`, which is written with an empty password.

## The change

`get_admin_password()` returns `ADMIN_PASSWORD` when it is set, and otherwise reads
`AdminPassword` from `PalWorldSettings.ini`. `REST_API()` and the `rcon.yaml` heredoc use it.

* `ADMIN_PASSWORD` keeps precedence, so behaviour is unchanged for every setup that sets it.
* With `DISABLE_GENERATE_SETTINGS=false` the `.ini` is generated from `ADMIN_PASSWORD`, so the
  fallback is a no-op there too.
* Resolution happens at call time, so it also covers `term_handler` in `init.sh` — the parent
  process, whose environment nothing else can reach.
* Only the quoted form the server and `compile-settings.sh` write (`AdminPassword="…"`) is
  matched; an unquoted hand edited value falls back to today's behaviour.
* `start.sh` logs a line when the fallback applies, so it is visible in the container log.

Deliberately out of scope: `RESTAPIPort` / `RESTAPIEnabled` have the same env vs `.ini` split
but are not part of this bug, so they are untouched.

## Testing

* `tests/test-admin-password.sh` (new, wired into `unit-test.yml`) covers: value read from the
  file, special characters preserved, `CRLF` stripped, empty `AdminPassword` rejected, missing
  file rejected, `ADMIN_PASSWORD` precedence, `.ini` used when `ADMIN_PASSWORD` is empty, and an
  unset `ADMIN_PASSWORD` tolerated.
* ShellCheck clean with `.shellcheckrc` (`external-sources=true`) on every script in the repo.
* The failure was reproduced on a live server running this image with `DISABLE_GENERATE_SETTINGS=true`
  and the password set only in the `.ini`: `curl -u "admin:$ADMIN_PASSWORD" …/v1/api/players` returns
  401 while the same call with the `.ini` password returns 200, and the nightly `auto_reboot.sh` job
  exits 1 every night. With this patch applied, `REST_API()` builds the call with the `.ini` password
  (checked with a stubbed `curl`), and with `ADMIN_PASSWORD` set it is unchanged.
* Pure bash and POSIX `tr`, no GNU only flags, nothing architecture specific.

## AI disclosure

Per `AI_GUIDELINES.md`: this patch was written with the help of an AI assistant. The failure was
diagnosed on a live production server first, the diff was reviewed by hand, and the tests and
ShellCheck run were executed locally rather than assumed.
