### PR TITLE
fix: give tail a file operand so term_handler cannot hang on SIGTERM

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -71,7 +71,7 @@ term_handler() {
         kill -SIGTERM "$(pidof PalServer-Linux-Shipping)"
     fi
 
-    tail --pid="$killpid" -f 2>/dev/null
+    tail --pid="$killpid" -f /dev/null 2>/dev/null
 }
 
 trap 'term_handler' SIGTERM
@@ -91,7 +91,7 @@ mapfile -t backup_pids < <(pgrep backup)
 if [ "${#backup_pids[@]}" -ne 0 ]; then
     LogInfo "Waiting for backup to finish"
     for pid in "${backup_pids[@]}"; do
-        tail --pid="$pid" -f 2>/dev/null
+        tail --pid="$pid" -f /dev/null 2>/dev/null
     done
 fi
 
@@ -99,6 +99,6 @@ mapfile -t restore_pids < <(pgrep restore)
 if [ "${#restore_pids[@]}" -ne 0 ]; then
     LogInfo "Waiting for restore to finish"
     for pid in "${restore_pids[@]}"; do
-        tail --pid="$pid" -f 2>/dev/null
+        tail --pid="$pid" -f /dev/null 2>/dev/null
     done
 fi


### PR DESCRIPTION
## Context

Closes #954

`term_handler` ends with `tail --pid="$killpid" -f 2>/dev/null`. The `2>/dev/null` is a stderr redirect, not an argument to `-f`, so `tail` is given no file to follow and falls back to standard input. With a TTY (`tty: true`, or `docker run -t`) that call never returns — GNU `tail` warns `following standard input indefinitely is ineffective` — so PID 1 stays blocked in the SIGTERM trap and Docker `SIGKILL`s the container at the end of `stop_grace_period`, exiting `137` every time.

The world itself saves correctly; only the wait afterwards hangs.

## Choices

* `/dev/null` gives `tail` a file to poll instead of stdin. It is the canonical form of this idiom and the smallest change that removes the dependency on stdin happening to be `/dev/null`.
* No behaviour change without a TTY — stdin is already `/dev/null` there, so `tail` returned immediately either way.
* The backup and restore waits (L94, L102) use the identical construct with the same latent flaw, so they are fixed too.

## Test instructions

1. Run `v2.7.3` with `tty: true` and `stop_grace_period: 30s`.
2. Wait for `Running Palworld dedicated server on :8211`.
3. `time docker compose stop`.

Verified on `v2.7.3` by patching `init.sh` in a running container and repeating the same `SIGTERM`:

| | result |
|---|---|
| before | never returned — observed at 30s, 60s, and a full 300s grace period; killed with `137` |
| after | exited on its own in **6.5s, exit code `0`** |

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the [docs](https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs) — no new or changed configuration to document, this only makes existing behavior work as intended.
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules. (ShellCheck passes on `scripts/init.sh` with the repo's `.shellcheckrc`.)

## AI Usage Disclosure

- [x] I used AI to assist in modifications for this PR. I have manually reviewed the generated code and tested it locally. To be precise: I verified the fix by patching `init.sh` inside a running `v2.7.3` container, not by rebuilding the image from the `Dockerfile`. Full reproduction and the coreutils references are in #954. This PR description was written by AI.
