### PR TITLE
fix(autopause): NFLOG monitor leaves orphaned child processes

### DIFF
--- a/scripts/autopause/knockd-ctl.sh
+++ b/scripts/autopause/knockd-ctl.sh
@@ -258,7 +258,7 @@ Nflog_startBackend() {
             echo "${monitorPid}" > "${Nflog_pidFile}"
             Nflog_saveState
             APLog_debug "Start NFLOG monitor (PID:${monitorPid}, chain:${Nflog_chainName}, group:${Nflog_group})"
-            return
+            return 0
         fi
 
         if [ -s "${Nflog_logFile}" ]; then
@@ -289,8 +289,11 @@ Nflog_stopBackend() {
 
     if [ -f "${Nflog_pidFile}" ]; then
         pid="$(cat "${Nflog_pidFile}")"
-        kill -TERM "${pid}" 2>/dev/null || true
+        # Kill children before the parent: once the pipe wrapper (pid) exits,
+        # its children (tcpdump and the "while read" loop) are reparented to
+        # init and "pkill -P" can no longer find them by that PPID.
         pkill -TERM -P "${pid}" 2>/dev/null || true
+        kill -TERM "${pid}" 2>/dev/null || true
         rm -f "${Nflog_pidFile}"
     fi
     Nflog_killTcpdump

--- a/scripts/autopause/services.sh
+++ b/scripts/autopause/services.sh
@@ -129,7 +129,13 @@ AutoPause_challengeToPause() {
 }
 
 AutoPause_waitWakeup() {
-    AP_startDaemon
+    if ! AP_startDaemon; then
+        # Without a working monitor there is no way to detect incoming
+        # traffic, so resume immediately instead of pausing forever.
+        APLog_error "Failed to start AUTO_PAUSE network monitor. Resuming without waiting for wakeup."
+        AP_pause off
+        return
+    fi
     isTrue "${COMMUNITY}" && APComm_init
     while true; do
         sleep 0.5


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->

Fixes the AUTO_PAUSE NFLOG monitor leaving orphaned processes behind after Resume: tcpdump and its pipe reader loop (while read) kept running instead of exiting. The cause was killing the pipe wrapper (parent) process before looking up its children via pkill -TERM -P; once the parent died, its children were immediately reparented to init, so the lookup could no longer find them by PPID. This PR also fixes AutoPause_waitWakeup staying paused forever with no way to wake up over the network if the NFLOG monitor fails to start.

<!-- What do you want to achieve with this PR? -->
Ensure the NFLOG monitor's child processes do not leak across repeated Pause/Resume cycles, and ensure the server resumes immediately instead of staying paused forever if the monitor fails to start.

## Choices

<!-- * Why did you solve it like this? -->
- Nflog_stopBackend: reordered so pkill -TERM -P "${pid}" (kill children) runs before kill -TERM "${pid}" (kill the parent). This lets the child lookup (tcpdump and the while read loop) succeed while the parent is still alive.
- Nflog_startBackend: made the success path return explicitly with "return 0" so the caller (via AP_startDaemon) can reliably check the result.
- AutoPause_waitWakeup: if AP_startDaemon fails, resume immediately with AP_pause off instead of entering the wait loop with no monitor running.

## Test instructions

1. Enable AUTO_PAUSE with the NFLOG backend (--cap-add=NET_ADMIN --cap-add=NET_RAW).
2. Trigger Pause and Resume multiple times in a row via RCON/REST API/LOGIN.
3. After each Resume, confirm inside the container that no tcpdump process or its paired reader loop (shown as "knockd-ctl start" in ps) remains.
4. Intentionally make the NFLOG monitor fail to start (e.g. remove the capability) and confirm the server resumes immediately instead of staying paused.
5. Confirm "bash -n scripts/autopause/knockd-ctl.sh" and "bash -n scripts/autopause/services.sh" both pass.

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the docs (https://github.com/thijsvanloef/palworld-server-docker/tree/main/docusaurus/docs).
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.

## AI Usage Disclosure

Please read the AI Usage Guidelines for Contributors (AI_GUIDELINES.md) before submitting this PR.
If you used an AI tool to assist in writing or refactoring code for this PR, please disclose it below.

- [x] I used GitHub Copilot to assist in modifications for this PR.
      I have manually reviewed the generated code and tested the container build locally.